### PR TITLE
Profile table

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,14 @@
+# TODO
+
+[NC 2021-06-28] 
+
+This is a simple MVP that logs all calls and stores profiles when execution
+time exceeds a trigger given in admin settings adding similar fields and checks
+should be pretty simple. Next steps:
+
+- To find bottlenecks, the flame graphs for the individual profiling should
+show time spent in each function, not just the total calls made to a function.
+
+- Need sorting and filtering for profile table on homepage: I've omitted a
+basic tablelib implementation here as I haven't gotten it right yet.
+

--- a/classes/excimer_profile.php
+++ b/classes/excimer_profile.php
@@ -55,10 +55,10 @@ class excimer_profile {
         $request = $_SERVER['PHP_SELF'] ?? 'UNKNOWN';
 
         if (self::is_cli()) {
-            // Web request: split CRON tasks later.
-            return;
-            //  $type = 'cli';
-            //  $parameters = join(' ', array_slice($argv, 1));
+            // Our setup lacks $argv even though register_argc_argv is On; use
+            // $_SERVER['argv'] instead.
+            $type = 'cli';
+            $parameters = join(' ', array_slice($_SERVER['argv'], 1));
         } else {
             // Web request: split API calls later.
             $type = 'web';
@@ -71,8 +71,9 @@ class excimer_profile {
         // Was the script too slow?
         $duration = round($stopped - $started, 6);
         $minduration = round((int)get_config('tool_excimer', 'excimertrigger_ms') / 1000, 6);
+        $s = 's';
         if ($duration > $minduration) {
-            $explanations[] = "Slower than $minduration\s ($duration\s)";
+            $explanations[] = "Slower than $minduration$s ($duration$s)";
         }
 
         // Add extra checks here...
@@ -109,9 +110,9 @@ class excimer_profile {
     /**
      * Listing of latest profile data
      *
-     * @return array e.g. [20210621 => [20 => 3451, ...], ...]
+     * @return iterable
      */
-    public static function listing($type='all', $limit=500) {
+    public static function listing() {
         global $DB;
         $sql = "
             SELECT *

--- a/classes/excimer_profile.php
+++ b/classes/excimer_profile.php
@@ -1,0 +1,156 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer;
+
+use ExcimerLog;
+use tool_excimer\excimer_helper;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Manage tool_excimer_profile table
+ *
+ * @package   tool_excimer
+ * @author    Nigel Chapman <nigelchapman@catalyst-au.net>
+ * @copyright 2021, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class excimer_profile {
+
+    /**
+     * Save Excimer log to tool_excimer_call, assuming profile has been created
+     * if needed. This should only be called if excimerenable_profiling is set.
+     *
+     * CREATE TABLE mdl_tool_excimer_profile (
+     *
+     *     id              BIGSERIAL,
+     *     type            VARCHAR(3)      NOT NULL DEFAULT '',
+     *     created         BIGINT          NOT NULL,
+     *     duration        NUMERIC(12,6)   NOT NULL,
+     *     request         VARCHAR(256)    NOT NULL DEFAULT '',
+     *     parameters      VARCHAR(256)    NOT NULL DEFAULT '',
+     *     responsecode    SMALLINT        NOT NULL DEFAULT 0,
+     *     explanation     VARCHAR(256)    NOT NULL DEFAULT '',
+     * );
+     *
+     */
+
+    public static function conditional_save($started, $stopped) {
+        global $DB;
+
+        $request = $_SERVER['PHP_SELF'] ?? 'UNKNOWN';
+
+        if (self::is_cli()) {
+            // Web request: split CRON tasks later.
+            return;
+            //  $type = 'cli';
+            //  $parameters = join(' ', array_slice($argv, 1));
+        } else {
+            // Web request: split API calls later.
+            $type = 'web';
+            $parameters = $_SERVER['QUERY_STRING'];
+        }
+
+        // Decide if there is any reason for saving this profile.
+        $explanations = [];
+
+        // Was the script too slow?
+        $duration = round($stopped - $started, 6);
+        $minduration = round((int)get_config('tool_excimer', 'excimertrigger_ms') / 1000, 6);
+        if ($duration > $minduration) {
+            $explanations[] = "Slower than $minduration\s ($duration\s)";
+        }
+
+        // Add extra checks here...
+        // Did we match a query string? (And not a NOT-match string?)
+        // Are we following a specific user?
+
+        // Save if necessary.
+        if (count($explanations) > 0) {
+            $record = (object) [
+                'created' => (int)$started,
+                'duration' => $duration,
+                'type' => $type,
+                'explanation' => join(', ', $explanations),
+                'request' => $request,
+                'parameters' => $parameters,
+            ];
+            try {
+                $id = $DB->insert_record('tool_excimer_profile', $record);
+            } catch (\Exception $e) {
+                // An exception would be thrown here if we were running
+                // uninstall, since the plugin tables would have been deleted.
+                debugging('Insert failed for tool_excimer_profile; table missing?');
+            }
+            return $id;
+        } else {
+            return null;
+        }
+    }
+
+    public static function is_cli() {
+        return php_sapi_name() === 'cli';
+    }
+
+    /**
+     * Listing of latest profile data
+     *
+     * @return array e.g. [20210621 => [20 => 3451, ...], ...]
+     */
+    public static function listing($type='all', $limit=500) {
+        global $DB;
+        $sql = "
+            SELECT *
+              FROM {tool_excimer_profile}
+          ORDER BY created DESC
+        ";
+        return $DB->get_recordset_sql($sql);
+    }
+
+    /**
+     * Count unique graphpaths in table (use MD5 shortcut for comparison).
+     *
+     * @return int
+     */
+    public static function count_profiles() {
+        global $DB;
+        $sql = "SELECT COUNT(*) FROM {tool_excimer_profile}";
+        return $DB->get_field_sql($sql);
+    }
+
+    /**
+     * Delete log entries earlier than a given time; but preserve whole hours.
+     *
+     * @param int $expirytime Epoch seconds
+     * @return void
+     */
+    public static function delete_before_epoch_time($expirytime) {
+        global $DB;
+        $expiryday = date('Ymd', $expirytime);
+        $expiryhour = date('H', $expirytime);
+        $DB->delete_records_select(
+            $table = 'tool_excimer_profile',
+            $where = 'day < :expiry_day1 OR (day = :expiry_day2 AND hour < :expiry_hour)',
+            $params = [
+                'expiry_day1' => $expiryday,
+                'expiry_day2' => $expiryday,
+                'expiry_hour' => $expiryhour,
+            ]
+        );
+    }
+
+}

--- a/classes/task/expire_logs.php
+++ b/classes/task/expire_logs.php
@@ -25,7 +25,7 @@
 
 namespace tool_excimer\task;
 
-use tool_excimer\excimer_log;
+use tool_excimer\excimer_call;
 
 /**
  * Delete logs that are past date...
@@ -43,7 +43,7 @@ class expire_logs extends \core\task\scheduled_task {
         }
         $expiry = (int)get_config('tool_excimer', 'excimerexpiry_s');
         $cutoff = time() - $expiry;
-        excimer_log::delete_before_epoch_time($cutoff);
+        excimer_call::delete_before_epoch_time($cutoff);
     }
 
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20210622" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20210625" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="tool_excimer" COMMENT="Table to store excimer log entries for excimer flamegraphs">
+    <TABLE NAME="tool_excimer_call" COMMENT="Table to store excimer log entries for excimer flamegraphs">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="day" TYPE="int" LENGTH="8" NOTNULL="true" SEQUENCE="false" COMMENT="e.g. 20210610 for 10 Jun 2021"/>
@@ -12,7 +12,8 @@
         <FIELD NAME="graphpath" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Graph path, semi-colon-separated"/>
         <FIELD NAME="graphpathmd5" TYPE="char" LENGTH="32" NOTNULL="true" SEQUENCE="false" COMMENT="Field for efficient comparison of graphpaths"/>
         <FIELD NAME="elapsed" TYPE="number" LENGTH="12" NOTNULL="true" SEQUENCE="false" DECIMALS="6" COMMENT="Time in seconds since ExcimerProfiler started"/>
-        <FIELD NAME="total" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Hourly hits for this graphpath"/>
+        <FIELD NAME="profileid" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="Optional link to profile table (where profile is collected)"/>
+        <FIELD NAME="total" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Number of times that the call happened during this request"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -20,6 +21,25 @@
       <INDEXES>
         <INDEX NAME="dayhourindex" UNIQUE="false" FIELDS="day, hour"/>
         <INDEX NAME="graphpathmd5index" UNIQUE="false" FIELDS="graphpathmd5"/>
+        <INDEX NAME="profileindex" UNIQUE="false" FIELDS="profileid" COMMENT="Enable fast joins on profileid"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="tool_excimer_profile" COMMENT="Store request-level data for the excimer sampling profiler">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="type" TYPE="char" LENGTH="3" NOTNULL="true" SEQUENCE="false" COMMENT="www, cli, api, crn"/>
+        <FIELD NAME="created" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="time in epoch seconds"/>
+        <FIELD NAME="duration" TYPE="number" LENGTH="12" NOTNULL="true" SEQUENCE="false" DECIMALS="6" COMMENT="time between excimer startup and shutdown calls"/>
+        <FIELD NAME="request" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="URL, command, or similar identifying string"/>
+        <FIELD NAME="parameters" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="Request variables or command arguments"/>
+        <FIELD NAME="responsecode" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="HTTP response code, or 0/1 for command line"/>
+        <FIELD NAME="explanation" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="Brief reason for collecting this profile"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="createdindex" UNIQUE="false" FIELDS="created"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/flamegraph.json.php
+++ b/flamegraph.json.php
@@ -38,7 +38,7 @@ $paramhour = $paramday !== null
     ? optional_param('hour', null, PARAM_INT)
     : null;
 
-if ($paramday === null || $paramprofile === null) {
+if ($paramday === null && $paramprofile === null) {
     return json_encode(['error' => 500]);
 } else if ($paramday !== null) {
     $data = excimer_call::get_time_based_data($paramday, $paramhour);

--- a/flamegraph.json.php
+++ b/flamegraph.json.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use tool_excimer\excimer_log;
+use tool_excimer\excimer_call;
 
 require_once(__DIR__ . '/../../../config.php');
 
@@ -32,15 +32,22 @@ require_once($CFG->libdir.'/adminlib.php');
 
 admin_externalpage_setup('tool_excimer_report');
 
+$paramprofile = optional_param('profile', null, PARAM_INT);
 $paramday = optional_param('day', null, PARAM_INT);
 $paramhour = $paramday !== null
     ? optional_param('hour', null, PARAM_INT)
     : null;
 
-if ($paramday === null) {
+if ($paramday === null || $paramprofile === null) {
     return json_encode(['error' => 500]);
+} else if ($paramday !== null) {
+    $data = excimer_call::get_time_based_data($paramday, $paramhour);
+} else if ($paramprofile !== null) {
+    $data = excimer_call::get_profile_data($paramprofile);
+} else {
+    $data = []; // Not possible.
 }
 
-$tree = excimer_log::tree_data($paramday, $paramhour);
 header('Content-Type: application/json; charset: utf-8');
+$tree = excimer_call::tree_data($data);
 echo json_encode($tree);

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -24,6 +24,8 @@
  */
 
 $string['pluginname'] = 'Excimer sampling profiler';
+
+// Admin.
 $string['excimerenable'] = 'Enable profiler';
 $string['excimerexpiry_s'] = 'Log expiry (days)';
 $string['excimertask_expire_logs'] = 'Expire excimer logs';
@@ -32,3 +34,16 @@ $string['excimerrequest_ms'] = 'Minimum request duration (milliseconds)';
 $string['excimeruri_contains'] = 'URI must contain';
 $string['excimeruri_not_contains'] = 'URI must NOT contain';
 $string['excimeruri_patterns_help'] = 'One pattern per line; * for wilcards';
+
+// Profile table.
+$string['excimerfield_id'] = 'ID';
+$string['excimerfield_type'] = 'Type';
+$string['excimerfield_created'] = 'Created';
+$string['excimerfield_explanation'] = 'Explanation';
+
+// Terminology.
+$string['excimerterm_profile'] = 'Profile';
+
+// Profile types.
+$string['excimertype_web'] = 'Web';
+$string['excimertype_cli'] = 'CLI';

--- a/lib.php
+++ b/lib.php
@@ -96,16 +96,20 @@ function tool_excimer_spool(ExcimerLog $log) {
  * @return void
  */
 function tool_excimer_shutdown(ExcimerProfiler $prof, $started) {
-    global $excimerlogs;
+    global $DB, $excimerlogs;
     $isenabled = (bool)get_config('tool_excimer', 'excimerenable');
     if ($isenabled) {
-        $stopped  = microtime($ms = true);
-        $prof->stop();
-        $prof->flush();
-        $id = excimer_profile::conditional_save($started, $stopped);
-        if (is_iterable($excimerlogs)) {
-            foreach ($excimerlogs as $log) {
-                excimer_call::save_log_entries($log, $started, $id);
+        // Running uninstall_package in CLI will error here unless we check.
+        $tableexists = $DB->get_manager()->table_exists('tool_excimer_call');
+        if ($tableexists) {
+            $stopped  = microtime($ms = true);
+            $prof->stop();
+            $prof->flush();
+            $id = excimer_profile::conditional_save($started, $stopped);
+            if (is_iterable($excimerlogs)) {
+                foreach ($excimerlogs as $log) {
+                    excimer_call::save_log_entries($log, $started, $id);
+                }
             }
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 /* tool_excimer styles */
 
-.path-admin-tool-excimer-index #loading {
+#page-admin-tool-excimer-index #loading {
     text-align: center;
     font-size: 2rem;
     color: #0f6fc5;


### PR DESCRIPTION
# TODO.md

[NC 2021-06-28] 

This is a simple MVP that logs all calls and stores profiles when execution
time exceeds a trigger given in admin settings adding similar fields and checks
should be pretty simple. Next steps:

- To find bottlenecks, the flame graphs for the individual profiling should
show time spent in each function, not just the total calls made to a function.

- Need sorting and filtering for profile table on homepage: I've omitted a
basic tablelib implementation here as I haven't gotten it right yet.

- NOTE: admin/cli/cron.php does not cleanup obsolete profiles yet; only calls. 