### PR TITLE
Issue #45: Limit number of auto saves per page.

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -151,24 +151,20 @@ class manager {
         } else {
             $reason = self::REASON_AUTO;
             $dowesave = ($duration * 1000) >= (int) get_config('tool_excimer', 'trigger_ms');
-            if ($dowesave) {
-                $numrecorded = profile::get_num_auto_profiles();
-                if ($numrecorded >= (int) get_config('tool_excimer', 'num_slowest')) {
-                    if ($duration <= profile::get_fastest_auto_profile()->duration) {
-                        $dowesave = false;
-                    } else {
-                        profile::purge_fastest_auto_profiles(1);
-                    }
-                }
-            }
         }
+
         if ($dowesave) {
             profile::save($log, $reason, (int) $started, $duration);
+
+            // TODO remove this to make this the task's responsibility.
+            profile::purge_fastest_by_page((int) get_config('tool_excimer', 'num_slowest_by_page'));
+            profile::purge_fastest((int) get_config('tool_excimer', 'num_slowest'));
         }
     }
 
     /**
      *  Callback for when the 'num_slowest' setting is changed.
+     *  TODO Once purging is done by cron, deprecate this function.
      *
      * @param string $name
      * @throws \dml_exception

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -244,10 +244,18 @@ class profile {
         global $DB;
 
         // TODO optimisation suggestions welcome.
-        $records = $DB->get_records_sql("select count(*) as num, request from mdl_tool_excimer_profiles where reason = ? group by request having count(*) > ?", [manager::REASON_AUTO, $numtokeep]);
+        $records = $DB->get_records_sql(
+            "SELECT COUNT(*) AS num, request
+               FROM {tool_excimer_profiles}
+              WHERE reason = ?
+           GROUP BY request
+             HAVING COUNT(*) > ?",
+            [manager::REASON_AUTO, $numtokeep]
+        );
         foreach ($records as $record) {
             $ids = array_keys($DB->get_records('tool_excimer_profiles',
-                    ['reason' => manager::REASON_AUTO, 'request' => $record->request ], 'duration ASC', 'id', 0, $record->num - $numtokeep));
+                    ['reason' => manager::REASON_AUTO, 'request' => $record->request ],
+                    'duration ASC', 'id', 0, $record->num - $numtokeep));
             $inclause = $DB->get_in_or_equal($ids);
             $DB->delete_records_select('tool_excimer_profiles', 'id ' . $inclause[0], $inclause[1]);
         }

--- a/classes/task/purge_fastest.php
+++ b/classes/task/purge_fastest.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify

--- a/classes/task/purge_fastest.php
+++ b/classes/task/purge_fastest.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -15,10 +16,10 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Delete logs that have expired
+ * Delete excess logs to keep only the slowest.
  *
  * @package   tool_excimer
- * @author    Nigel Chapman <nigelchapman@catalyst-au.net>
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2021, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -27,15 +28,14 @@ namespace tool_excimer\task;
 
 use tool_excimer\profile;
 
-class expire_logs extends \core\task\scheduled_task {
+class purge_fastest  extends \core\task\scheduled_task {
 
     public function get_name() {
-        return get_string('task_expire_logs', 'tool_excimer');
+        return get_string('task_purge_fastest', 'tool_excimer');
     }
 
     public function execute() {
-        $expiry = (int)get_config('tool_excimer', 'expiry_s');
-        $cutoff = time() - $expiry;
-        profile::purge_profiles_before_epoch_time($cutoff);
+        profile::purge_fastest_by_page((int) get_config('tool_excimer', 'num_slowest_by_page'));
+        profile::purge_fastest((int) get_config('tool_excimer', 'num_slowest'));
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -29,6 +29,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="createdindex" UNIQUE="false" FIELDS="created"/>
+        <INDEX NAME="durationindex" UNIQUE="false" FIELDS="duration"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -35,5 +35,14 @@ $tasks = array(
         'day' => '*',
         'month' => '*',
         'dayofweek' => '*'
+    ),
+    array(
+        'classname' => 'tool_excimer\task\purge_fastest',
+        'blocking' => 0,
+        'minute' => '0',
+        'hour' => '*',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*'
     )
 );

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -34,9 +34,10 @@ $string['enable_auto'] = 'Enable auto profiling';
 $string['enable_auto_desc'] = 'Any page will be automatically profiled if they exceed the miniumum duration.';
 $string['expiry_s'] = 'Log expiry (days)';
 $string['expiry_s_desc'] = 'Remove profiles after this long.';
-$string['num_slowest'] = 'Number of saves';
+$string['num_slowest'] = 'Max to save';
 $string['num_slowest_desc'] = 'Only the N slowest profiles will be kept.';
 $string['task_expire_logs'] = 'Expire excimer logs';
+$string['task_purge_fastest'] = 'Purge fastest excimer profiles';
 $string['period_ms'] = 'Sampling period (milliseconds)';
 $string['period_ms_desc'] = 'Frequency of sampling.';
 $string['request_ms'] = 'Minimum request duration (milliseconds)';
@@ -44,6 +45,8 @@ $string['request_ms_desc'] = 'Record a profile only if it runs at least this lon
 $string['uri_contains'] = 'URI must contain';
 $string['uri_not_contains'] = 'URI must NOT contain';
 $string['uri_patterns_help'] = 'One pattern per line; * for wildcards';
+$string['num_slowest_by_page'] = 'Max to save by page';
+$string['num_slowest_by_page_desc'] = 'Only the N slowest profiles will be kept for each script page.';
 
 // Profile table.
 $string['field_id'] = 'ID';

--- a/settings.php
+++ b/settings.php
@@ -99,10 +99,20 @@ if ($hassiteconfig) {
             'tool_excimer/num_slowest',
             get_string('num_slowest', 'tool_excimer'),
             get_string('num_slowest_desc', 'tool_excimer'),
-            '5',
+            '100',
             PARAM_INT
         );
         $setting->set_updatedcallback('tool_excimer\manager::on_num_slow_setting_change');
         $settings->add($setting);
+
+        $settings->add(
+                new admin_setting_configtext(
+                        'tool_excimer/num_slowest_by_page',
+                        get_string('num_slowest_by_page', 'tool_excimer'),
+                        get_string('num_slowest_by_page_desc', 'tool_excimer'),
+                        '5',
+                        PARAM_INT
+                )
+        );
     }
 }

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -90,7 +90,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
 
         $fastmanual = 0.003;
 
-        // Non-auto saves should have no impact, so chuck a few in o see if it gumms up the works.
+        // Non-auto saves should have no impact, so chuck a few in to see if it gumms up the works.
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
         profile::save($log, manager::REASON_FLAMEALL, 12345, 0.104);
 
@@ -142,7 +142,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         sort($sortedtimes);
         $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
 
-        // Non-auto saves should have no impact, so chuck a few in o see if it gumms up the works.
+        // Non-auto saves should have no impact, so chuck a few in to see if it gumms up the works.
         $_SERVER['PHP_SELF'] = 'a';
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
         $_SERVER['PHP_SELF'] = 'b';
@@ -157,8 +157,6 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         profile::save($log, manager::REASON_MANUAL, 12345, 0.001);
 
         $this->assertEquals(count($times) + 3, $DB->count_records('tool_excimer_profiles'));
-
-        $x = $DB->get_records('tool_excimer_profiles');
 
         // Should remove a few profiles.
         $numtokeep = 3;

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -20,6 +20,14 @@ use tool_excimer\profile;
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Tests the profile storage.
+ *
+ * @package   tool_excimer
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright 2021, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class tool_excimer_profile_testcase extends advanced_testcase {
 
     /**
@@ -71,42 +79,105 @@ class tool_excimer_profile_testcase extends advanced_testcase {
      * @throws dml_exception
      */
     public function test_n_slowest_kept(): void {
-        $numtokeep = 5;
-        set_config('num_slowest', $numtokeep, 'tool_excimer');
-        set_config('enable_auto', 1, 'tool_excimer');
-        set_config('trigger_ms', 0, 'tool_excimer');
+        global $DB;
 
-        // Manual saves should have no impact, so chuck a few in o see if it gumms up the works.
-        profile::save(self::quick_log(10), manager::REASON_MANUAL, 12345, 2.345);
+        $log = self::quick_log(10);
 
-        // Test number of profiles never exceed max allowed.
-        for ($i = 1; $i < $numtokeep + 2; ++$i) {
-            $expectednum = min($i, $numtokeep);
-            $started = microtime(true);
-            $log = $this->quick_log(5 * ($i + 100));
-            manager::on_flush($log, $started);
-            $this->assertEquals($expectednum, profile::get_num_auto_profiles());
+        $times = [ 0.345, 0.234, 0.123, 0.456, 0.4, 0.5, 0.88, 0.1, 0.14, 0.22 ];
+        $sortedtimes = $times;
+        sort($sortedtimes);
+        $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
+
+        $fastmanual = 0.003;
+
+        // Non-auto saves should have no impact, so chuck a few in o see if it gumms up the works.
+        profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
+        profile::save($log, manager::REASON_FLAMEALL, 12345, 0.104);
+
+        foreach ($times as $time) {
+            profile::save($log, manager::REASON_AUTO, 12345, $time);
         }
 
-        profile::save(self::quick_log(10), manager::REASON_MANUAL, 2345, 2.456);
+        profile::save($log, manager::REASON_MANUAL, 12345, 0.001);
 
-        // Test run that is faster than what's on there.
-        $fastest = profile::get_fastest_auto_profile();
-        $started = microtime(true);
-        $log = $this->quick_log(5 * 10); // Should be quicker than any of the above.
-        manager::on_flush($log, $started);
-        $this->assertEquals($fastest->duration, profile::get_fastest_auto_profile()->duration);
-        $this->assertEquals($numtokeep, profile::get_num_auto_profiles());
+        $this->assertEquals(count($times) + 3, $DB->count_records('tool_excimer_profiles'));
 
-        profile::save(self::quick_log(10), manager::REASON_MANUAL, 65432, 0.0012);
+        // Should remove a few profiles.
+        $numtokeep = 8;
+        profile::purge_fastest($numtokeep);
+        $this->assertEquals($numtokeep + 3, $DB->count_records('tool_excimer_profiles'));
+        $sortedtimes = array_slice($sortedtimes, -$numtokeep);
+        $this->assertEquals($sortedtimes[0],
+                $DB->get_field_sql("select min(duration) from {tool_excimer_profiles} where reason = ?", [manager::REASON_AUTO]));
 
-        // Test run that is slower than what's on there.
-        $fastest = profile::get_fastest_auto_profile();
-        $started = microtime(true);
-        $log = $this->quick_log(5 * 1000); // Should be slower than any of the above.
-        manager::on_flush($log, $started);
-        $this->assertGreaterThan($fastest->duration, profile::get_fastest_auto_profile()->duration);
-        $this->assertEquals($numtokeep, profile::get_num_auto_profiles());
+        // Should remove a few more profiles.
+        $numtokeep = 5;
+        profile::purge_fastest($numtokeep);
+        $this->assertEquals($numtokeep + 3, $DB->count_records('tool_excimer_profiles'));
+        $sortedtimes = array_slice($sortedtimes, -$numtokeep);
+        $this->assertEquals($sortedtimes[0],
+                $DB->get_field_sql("select min(duration) from {tool_excimer_profiles} where reason = ?", [manager::REASON_AUTO]));
+
+        // Should remove no profiles.
+        $numtokeepnew = 9;
+        profile::purge_fastest($numtokeepnew);
+        $this->assertEquals($numtokeep + 3, $DB->count_records('tool_excimer_profiles'));
+        $this->assertEquals($sortedtimes[0],
+                $DB->get_field_sql("select min(duration) from {tool_excimer_profiles} where reason = ?", [manager::REASON_AUTO]));
+    }
+
+    /**
+     * Tests the functionality to keep only the N slowest profiles for each page.
+     *
+     * @throws dml_exception
+     */
+    public function test_n_slowest_kept_per_page(): void {
+        global $DB;
+
+        $log = self::quick_log(10);
+
+        $times = [ 0.345, 0.234, 0.123, 0.456, 0.4, 0.5, 0.88, 0.1, 0.14, 0.22, 0.111, 0.9 ];
+        $reqnames = [ 'a', 'b', 'c', 'a', 'd', 'a', 'a', 'c', 'd', 'c', 'c', 'c' ];
+        $sortedtimes = $times;
+        sort($sortedtimes);
+        $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
+
+        // Non-auto saves should have no impact, so chuck a few in o see if it gumms up the works.
+        $_SERVER['PHP_SELF'] = 'a';
+        profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
+        $_SERVER['PHP_SELF'] = 'b';
+        profile::save($log, manager::REASON_FLAMEALL, 12345, 0.104);
+
+        for ($i = 0; $i < count($times); ++$i) {
+            $_SERVER['PHP_SELF'] = $reqnames[$i];
+            profile::save($log, manager::REASON_AUTO, 12345, $times[$i]);
+        }
+
+        $_SERVER['PHP_SELF'] = 'c';
+        profile::save($log, manager::REASON_MANUAL, 12345, 0.001);
+
+        $this->assertEquals(count($times) + 3, $DB->count_records('tool_excimer_profiles'));
+
+        $x = $DB->get_records('tool_excimer_profiles');
+
+        // Should remove a few profiles.
+        $numtokeep = 3;
+        $expectedreqcount = [ 'a' => 3, 'b' => 1, 'c' => 3, 'd' => 2 ];
+        $expectedfastest = [ 'a' => 0.456, 'b' => 0.234, 'c' => 0.123, 'd' => 0.14 ];
+        profile::purge_fastest_by_page($numtokeep);
+        $this->assertEquals(array_sum($expectedreqcount) + 3, $DB->count_records('tool_excimer_profiles'));
+        $records = $DB->get_records_sql(
+            "SELECT request, COUNT(*) AS c, MIN(duration) AS m
+               FROM {tool_excimer_profiles}
+              WHERE reason = ?
+           GROUP BY request",
+            [manager::REASON_AUTO]
+        );
+
+        foreach ($records as $i => $record) {
+            $this->assertEquals($expectedreqcount[$i], $record->c);
+            $this->assertEquals($expectedfastest[$i], $record->m);
+        }
     }
 
     /**
@@ -207,7 +278,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         foreach ($times as $time) {
             profile::save($log, manager::REASON_AUTO, 12345, $time);
         }
-        $manualid = profile::save($log, manager::REASON_MANUAL, 12345, $fastmanual);
+        profile::save($log, manager::REASON_MANUAL, 12345, $fastmanual);
 
         $tocheck = profile::get_fastest_auto_profile();
         $this->assertEquals($sortedtimes[0], $tocheck->duration);

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -90,7 +90,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
 
         $fastmanual = 0.003;
 
-        // Non-auto saves should have no impact, so chuck a few in to see if it gumms up the works.
+        // Non-auto saves should have no impact, so chuck a few in to see if it gums up the works.
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
         profile::save($log, manager::REASON_FLAMEALL, 12345, 0.104);
 
@@ -142,7 +142,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         sort($sortedtimes);
         $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
 
-        // Non-auto saves should have no impact, so chuck a few in to see if it gumms up the works.
+        // Non-auto saves should have no impact, so chuck a few in to see if it gums up the works.
         $_SERVER['PHP_SELF'] = 'a';
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
         $_SERVER['PHP_SELF'] = 'b';


### PR DESCRIPTION
Added cron task purge_fastest. #45
Added two functions purge_fastest(), purge_fastest_by_page()
Other purge related functions are deprecated.
Added num_slowest_by_page setting.
Added duration index to database.