### PR TITLE
Issue #37: Redacted Parameters

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -34,10 +34,13 @@ class profile {
     const SCRIPTTYPE_WS = 3;
 
     const DENYLIST = [
-        'sesskey',
         manager::MANUAL_PARAM_NAME,
         manager::FLAME_ON_PARAM_NAME,
         manager::FLAME_OFF_PARAM_NAME
+    ];
+
+    const REDACTLIST = [
+        'sesskey',
     ];
 
     /**
@@ -47,13 +50,21 @@ class profile {
      * @return array
      */
     public static function stripparameters(array $parameters): array {
-        return array_filter(
+        $parameters = array_filter(
             $parameters,
             function($i) {
-                return !in_array($i, profile::DENYLIST);
+                return !in_array($i, self::DENYLIST);
             },
             ARRAY_FILTER_USE_KEY
         );
+
+        foreach ($parameters as $i => &$v) {
+            if (in_array($i, self::REDACTLIST)) {
+                $v = '';
+            }
+        }
+
+        return $parameters;
     }
 
     /**

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -287,4 +287,18 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         set_config('enable_auto', 0, 'tool_excimer');
         $this->assertFalse(manager::is_profiling());
     }
+
+    public function test_stripparamters(): void {
+        $param = [ 'a' => '1', 'b' => 2, 'c' => 3 ];
+        $paramexpect = $param;
+        $this->assertEquals($paramexpect, profile::stripparameters($param));
+
+        $param = [ 'a' => '1', 'sesskey' => 2, 'c' => 3 ];
+        $paramexpect = [ 'a' => '1', 'sesskey' => '', 'c' => 3 ];
+        $this->assertEquals($paramexpect, profile::stripparameters($param));
+
+        $param = [ 'a' => '1', 'sesskey' => 2, 'FLAMEME' => 3 ];
+        $paramexpect = [ 'a' => '1', 'sesskey' => '' ];
+        $this->assertEquals($paramexpect, profile::stripparameters($param));
+    }
 }


### PR DESCRIPTION
Function profile::stripparameters() will now redact (set to empty) parameters that are in profile::REDACTLIST
Added test_stripparameters() to unit tests.
'sesskey' is now redacted rather then deleted.