### PR TITLE
Align request path prefixes

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -159,11 +159,15 @@ class profile {
      * @throws \dml_exception
      */
     public static function save(\ExcimerLog $log, int $reason, int $created, float $duration): int {
-        global $DB, $USER;
+        global $DB, $USER, $SCRIPT;
         $flamedata = trim(str_replace("\n;", "\n", $log->formatCollapsed()));
         $flamedatad3 = json_encode(converter::process($flamedata));
         $type = self::get_script_type();
         $parameters = self::get_parameters($type);
+
+        // If set, it will trim off the leading '/' to normalise web & cli requests.
+        $request = isset($SCRIPT) ? ltrim($SCRIPT, '/') : 'UNKNOWN';
+
         return $DB->insert_record('tool_excimer_profiles', [
             'sessionid' => substr(session_id(), 0, 10),
             'reason' => $reason,
@@ -172,7 +176,7 @@ class profile {
             'method' => $_SERVER['REQUEST_METHOD'] ?? '',
             'created' => $created,
             'duration' => $duration,
-            'request' => $_SERVER['PHP_SELF'] ?? 'UNKNOWN',
+            'request' => $request,
             'parameters' => $parameters,
             'cookies' => !defined('NO_MOODLE_COOKIES') || !NO_MOODLE_COOKIES,
             'buffering' => !defined('NO_OUTPUT_BUFFERING') || !NO_OUTPUT_BUFFERING,

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -28,6 +28,9 @@ defined('MOODLE_INTERNAL') || die();
  */
 class profile {
 
+    /** Request's fallback value for when the $SCRIPT is null */
+    const REQUEST_UNKNOWN = 'UNKNOWN';
+
     const SCRIPTTYPE_AJAX = 0;
     const SCRIPTTYPE_CLI = 1;
     const SCRIPTTYPE_WEB = 2;
@@ -170,7 +173,7 @@ class profile {
         $parameters = self::get_parameters($type);
 
         // If set, it will trim off the leading '/' to normalise web & cli requests.
-        $request = isset($SCRIPT) ? ltrim($SCRIPT, '/') : 'UNKNOWN';
+        $request = isset($SCRIPT) ? ltrim($SCRIPT, '/') : self::REQUEST_UNKNOWN;
 
         return $DB->insert_record('tool_excimer_profiles', [
             'sessionid' => substr(session_id(), 0, 10),

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -159,8 +159,12 @@ class profile {
      * @throws \dml_exception
      */
     public static function save(\ExcimerLog $log, int $reason, int $created, float $duration): int {
-        global $DB, $USER, $SCRIPT;
+        global $DB, $USER, $CFG, $SCRIPT;
         $flamedata = trim(str_replace("\n;", "\n", $log->formatCollapsed()));
+
+        // Remove full pathing to dirroot and only keep pathing from site root (non-issue in most sane cases).
+        $flamedata = str_replace($CFG->dirroot . DIRECTORY_SEPARATOR, '', $flamedata);
+
         $flamedatad3 = json_encode(converter::process($flamedata));
         $type = self::get_script_type();
         $parameters = self::get_parameters($type);

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -81,14 +81,12 @@ class tool_excimer_profile_testcase extends advanced_testcase {
     public function test_n_slowest_kept(): void {
         global $DB;
 
-        $log = self::quick_log(10);
+        $log = $this->quick_log(10);
 
         $times = [ 0.345, 0.234, 0.123, 0.456, 0.4, 0.5, 0.88, 0.1, 0.14, 0.22 ];
         $sortedtimes = $times;
         sort($sortedtimes);
         $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
-
-        $fastmanual = 0.003;
 
         // Non-auto saves should have no impact, so chuck a few in to see if it gums up the works.
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
@@ -134,7 +132,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
     public function test_n_slowest_kept_per_page(): void {
         global $DB;
 
-        $log = self::quick_log(10);
+        $log = $this->quick_log(10);
 
         $times = [ 0.345, 0.234, 0.123, 0.456, 0.4, 0.5, 0.88, 0.1, 0.14, 0.22, 0.111, 0.9 ];
         $reqnames = [ 'a', 'b', 'c', 'a', 'd', 'a', 'a', 'c', 'd', 'c', 'c', 'c' ];
@@ -184,10 +182,12 @@ class tool_excimer_profile_testcase extends advanced_testcase {
      * @throws dml_exception
      */
     public function test_save(): void {
-        global $DB;
+        global $DB, $CFG;
 
-        $log = self::quick_log(150);
+        $log = $this->quick_log(150);
         $flamedata = trim(str_replace("\n;", "\n", $log->formatCollapsed()));
+        // Remove full pathing to dirroot and only keep pathing from site root (non-issue in most sane cases).
+        $flamedata = str_replace($CFG->dirroot . DIRECTORY_SEPARATOR, '', $flamedata);
         $flamedatad3 = json_encode(converter::process($flamedata));
         $reason = manager::REASON_AUTO;
         $created = 56;
@@ -204,8 +204,10 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         $this->assertEquals($flamedata, $record->flamedata);
         $this->assertEquals($flamedatad3, $record->flamedatad3);
 
-        $log = self::quick_log(1500);
+        $log = $this->quick_log(1500);
         $flamedata = trim(str_replace("\n;", "\n", $log->formatCollapsed()));
+        // Remove full pathing to dirroot and only keep pathing from site root (non-issue in most sane cases).
+        $flamedata = str_replace($CFG->dirroot . DIRECTORY_SEPARATOR, '', $flamedata);
         $flamedatad3 = json_encode(converter::process($flamedata));
         $reason = manager::REASON_AUTO;
         $created = 120;
@@ -230,7 +232,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
      */
     public function test_purge_old_profiles(): void {
         global $DB;
-        $log = self::quick_log(10);
+        $log = $this->quick_log(10);
         $times = [ 12345, 23456, 34567, 45678 ];
         $cutoff1 = 30000;
         $cutoff2 = 20000;

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -130,7 +130,7 @@ class tool_excimer_profile_testcase extends advanced_testcase {
      * @throws dml_exception
      */
     public function test_n_slowest_kept_per_page(): void {
-        global $DB;
+        global $DB, $SCRIPT;
 
         $log = $this->quick_log(10);
 
@@ -141,17 +141,17 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         $this->assertGreaterThan($sortedtimes[0], $sortedtimes[1]); // Sanity check.
 
         // Non-auto saves should have no impact, so chuck a few in to see if it gums up the works.
-        $_SERVER['PHP_SELF'] = 'a';
+        $SCRIPT = 'a';
         profile::save($log, manager::REASON_MANUAL, 12345, 2.345);
-        $_SERVER['PHP_SELF'] = 'b';
+        $SCRIPT = 'b';
         profile::save($log, manager::REASON_FLAMEALL, 12345, 0.104);
 
         for ($i = 0; $i < count($times); ++$i) {
-            $_SERVER['PHP_SELF'] = $reqnames[$i];
+            $SCRIPT = $reqnames[$i];
             profile::save($log, manager::REASON_AUTO, 12345, $times[$i]);
         }
 
-        $_SERVER['PHP_SELF'] = 'c';
+        $SCRIPT = 'c';
         profile::save($log, manager::REASON_MANUAL, 12345, 0.001);
 
         $this->assertEquals(count($times) + 3, $DB->count_records('tool_excimer_profiles'));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9924643/145944107-33233cd2-898f-474d-98b6-9604579c6011.png)

* [x] Remove the / from the web ones.
* [x] Remove wwwroot from paths inside the profile flame

> Also check what happens if moodle is installed under /somedir/admin/cli etc. I think in all cases remove the wwwroot prefix 

I believe based on the above adjustments, it shouldn't really care about where it's installed. If it's installed under a weird path that replicates the directory structure of the moodle site, that's an edge case which I don't think would happen in a normal sane environment, unless moodle starts changing their pathing to end up with something like `/path/to/site/var/log` and the user installs it under `/var/log`

Closes #51 