### PR TITLE
Add pathinfo to profiles

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -31,6 +31,18 @@ class profile {
     /** Request's fallback value for when the $SCRIPT is null */
     const REQUEST_UNKNOWN = 'UNKNOWN';
 
+    /** Report section - recent - lists the most recent profiles first */
+    const REPORT_SECTION_RECENT = 'recent';
+
+    /** Report section - slowest - lists the slowest profiles first */
+    const REPORT_SECTION_SLOWEST = 'slowest';
+
+    /** Report sections */
+    const REPORT_SECTIONS = [
+      self::REPORT_SECTION_RECENT,
+      self::REPORT_SECTION_SLOWEST,  
+    ];
+
     const SCRIPTTYPE_AJAX = 0;
     const SCRIPTTYPE_CLI = 1;
     const SCRIPTTYPE_WEB = 2;

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -174,10 +174,12 @@ class profile {
 
         // If set, it will trim off the leading '/' to normalise web & cli requests.
         $request = isset($SCRIPT) ? ltrim($SCRIPT, '/') : self::REQUEST_UNKNOWN;
+        $pathinfo = $_SERVER['PATH_INFO'] ?? '';
 
         return $DB->insert_record('tool_excimer_profiles', [
             'sessionid' => substr(session_id(), 0, 10),
             'reason' => $reason,
+            'pathinfo' => $pathinfo,
             'scripttype' => $type,
             'userid' => $USER ? $USER->id : 0,
             'method' => $_SERVER['REQUEST_METHOD'] ?? '',

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -56,7 +56,7 @@ class profile_table extends \table_sql {
         }
 
         $this->set_sql(
-            '{tool_excimer_profiles}.id as id, reason, scripttype, request, created, duration, parameters, responsecode,
+            '{tool_excimer_profiles}.id as id, reason, scripttype, method, request, pathinfo, created, duration, parameters, responsecode,
                      referer, userid, lang, firstname, lastname, firstnamephonetic, lastnamephonetic, middlename, alternatename',
             '{tool_excimer_profiles} LEFT JOIN {user} on ({tool_excimer_profiles}.userid = {user}.id)',
             '1=1'
@@ -107,14 +107,19 @@ class profile_table extends \table_sql {
      * @return string
      */
     public function col_request(object $record): string {
-        if ($this->is_downloading()) {
-            return $record->request;
-        } else {
-            return \html_writer::link(
-                new \moodle_url('/admin/tool/excimer/profile.php', ['id' => $record->id]),
-                $record->request
-            );
+        $displayedrequest = $record->request . $record->pathinfo;
+        if ($record->method === 'GET' && !empty($record->parameters)) {
+            $displayedrequest .= '?' . urldecode($record->parameters);
         }
+
+        if ($this->is_downloading()) {
+            return $displayedrequest;
+        }
+
+        return \html_writer::link(
+                new \moodle_url('/admin/tool/excimer/profile.php', ['id' => $record->id]),
+                shorten_text($displayedrequest, 100, true, '…'),
+                ['title' => $displayedrequest, 'style' => 'word-break: break-all']);
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20211130" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20211215" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -13,6 +13,7 @@
         <FIELD NAME="created" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="time in epoch seconds"/>
         <FIELD NAME="duration" TYPE="number" LENGTH="12" NOTNULL="true" SEQUENCE="false" DECIMALS="6" COMMENT="time between excimer startup and shutdown calls"/>
         <FIELD NAME="request" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="URL, command, or similar identifying string"/>
+        <FIELD NAME="pathinfo" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="See PHP documentation on $_SERVER['PATH_INFO'] for more information."/>
         <FIELD NAME="parameters" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="Request variables or command arguments"/>
         <FIELD NAME="sessionid" TYPE="char" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Session ID"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="User ID"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -26,12 +26,26 @@
 defined('MOODLE_INTERNAL') || die;
 
 function xmldb_tool_excimer_upgrade($oldversion) {
-    global $CFG, $DB;
+    global $DB;
 
     $dbman = $DB->get_manager();
 
     // Automatically generated Moodle v3.11.0 release upgrade line.
     // Put any upgrade step following this.
+    if ($oldversion < 2021121500) {
+
+        // Define field pathinfo to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('pathinfo', XMLDB_TYPE_CHAR, '256', null, XMLDB_NOTNULL, null, null, 'request');
+
+        // Conditionally launch add field pathinfo.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2021121500, 'tool', 'excimer');
+    }
 
     return true;
 }

--- a/profile.php
+++ b/profile.php
@@ -39,8 +39,12 @@ $PAGE->set_context($context);
 $PAGE->set_url($url);
 
 $returnurl = get_local_referer(false);
-$report = basename($returnurl, '.php');
 
+// The page's breadcrumb will include a link to the reports for recent or slowest (default).
+// Handling here prevents things links from other pages and paginated listings
+// from breaking the output of this page.
+$report = explode('.php', basename($returnurl, '.php'))[0] ?? null;
+$report = in_array($report, profile::REPORT_SECTIONS) ? $report : profile::REPORT_SECTION_SLOWEST;
 admin_externalpage_setup('tool_excimer_report_' . $report);
 
 $pluginname = get_string('pluginname', 'tool_excimer');

--- a/profile.php
+++ b/profile.php
@@ -23,7 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use tool_excimer\manager;
 use tool_excimer\profile;
 use tool_excimer\helper;
 
@@ -50,7 +49,7 @@ $url = new moodle_url("/admin/tool/excimer/index.php");
 
 $profile = profile::getprofile($profileid);
 
-$PAGE->navbar->add($profile->request);
+$PAGE->navbar->add($profile->request . $profile->pathinfo);
 $PAGE->set_title($pluginname);
 $PAGE->set_pagelayout('admin');
 $PAGE->set_heading($pluginname);
@@ -64,7 +63,24 @@ $deletebutton = new \single_button($deleteurl, get_string('deleteprofile', 'tool
 $deletebutton->add_confirm_action(get_string('deleteprofilewarning', 'tool_excimer'));
 
 $data = (array) $profile;
-$data['duration'] = helper::duration_display($profile->duration);
+$data['duration'] = format_time($data['duration']);
+
+$data['request'] = $profile->request . $profile->pathinfo;
+if ($profile->method === 'GET' && !empty($profile->parameters)) {
+    $data['request'] .= '?' . htmlentities($profile->parameters);
+}
+// If GET request then it should be reproducable as a idempotent request (readonly).
+if ($profile->method === 'GET') {
+    $requesturl = new \moodle_url('/' . $data['request']);
+    $data['request'] = \html_writer::link(
+            $requesturl,
+            urldecode($data['request']),
+            [
+                'rel' => 'noreferrer noopener',
+                'target' => '_blank',
+            ]);
+}
+
 $data['script_type_display'] = function($text, $render) {
     return helper::script_type_display((int)$render($text));
 };

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -27,13 +27,12 @@
 
     Context variables required for this template:
     * id - The id of the profile
-    * request - The request url (without parameters)
+    * request - The request url (with pathinfo and parameters)
     * sessionid - The session ID
     * userid - ID of the user who loaded the page
     * scripttype - The script type
     * created - Unix timestamp of profile creation
     * duration - Profile duration in seconds.
-    * parameters - Parameter string
     * resposnecode - HTTP response code
     * cookies - Is cookies enabled?
     * buffering - Is buffering enabled?
@@ -43,12 +42,11 @@
     Example context (json):
     {
         "id" : 3,
-        "request" : "/my/index.php",
+        "request" : "/my/index.php/another/deeper/path?time=day&duration=week",
         "sessionid" : "9842abcdef",
         "scripttype" : 2,
         "created" : 1638244603,
         "duration" : 0.153,
-        "paramters" : "time=day&duration=week",
         "resposnecode" : 200,
         "cookies" : 1,
         "buffering" : 1,
@@ -63,7 +61,7 @@
     <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
         <tr>
             <th>{{#str}} field_request, tool_excimer {{/str}}</th>
-            <td>{{request}}</td>
+            <td>{{{request}}}</td>
         </tr>
         <tr>
             <th>{{#str}} field_sessionid, tool_excimer {{/str}}</th>
@@ -86,10 +84,6 @@
             <td>{{{duration}}}</td>
         </tr>
         <tr>
-            <th>{{#str}} field_parameters, tool_excimer {{/str}}</th>
-            <td>{{parameters}}</td>
-        </tr>
-        <tr>
             <th>{{#str}} field_user, tool_excimer {{/str}}</th>
             <td>{{#userlink}}<a href="{{userlink}}">{{fullname}}</a>{{/userlink}}
                 {{^userlink}}{{fullname}}{{/userlink}}</td>
@@ -97,10 +91,6 @@
         <tr>
             <th>{{#str}} field_responsecode, tool_excimer {{/str}}</th>
             <td>{{{responsecode}}}</td>
-        </tr>
-        <tr>
-            <th>{{#str}} field_referer, tool_excimer {{/str}}</th>
-            <td>{{referer}}</td>
         </tr>
         <tr>
             <th>{{#str}} field_cookies, tool_excimer {{/str}}</th>

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021112900;
-$plugin->release = 2021062400;
+$plugin->version = 2021121500;
+$plugin->release = 2021121500;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
This should record the full details for a pluginfile.php request so it can be reconstructed if needed.

Changes highlighted below:

Profile changes:
- add pathinfo and parameters to request text displayed (no truncate, full url displayed)
- parameters will still exist but will show as not-encoded / clear for readers
- referer will be a clickable link

![image](https://user-images.githubusercontent.com/9924643/146293900-9bac6aea-f757-4ab3-b9e7-ba925987e1fb.png)

List changes: 
- add pathinfo and parameters to request text displayed, 
- removed parameters column as a result of the above
- truncated display to 100 characters
- title attribute will show full request if curious

![image](https://user-images.githubusercontent.com/9924643/146294007-f86b2fd6-103f-4e15-8970-d5ff0add8848.png)

Adjusted to 100 characters - word-break: break-all

![image](https://user-images.githubusercontent.com/9924643/146294941-c65008b1-0609-47fc-b9c4-634dd2bceecc.png)

Closes #76
Closes #82