### PR TITLE
Issue #59: Cosmetic fixes

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -29,6 +29,16 @@ defined('MOODLE_INTERNAL') || die();
 class helper {
 
     /**
+     * Maps HTTP status codes to css badges.
+     */
+    const STATUS_BADGES = [
+        2 => 'badge-success',
+        3 => 'badge-info',
+        4 => 'badge-warning',
+        5 => 'badge-error',
+    ];
+
+    /**
      * Returns a printable string for a script type value.
      *
      * @param int $type
@@ -69,5 +79,28 @@ class helper {
                 return (string) $reason;
         }
     }
-}
 
+    /**
+     * Returns a formatted time duration in m:s.ms format.
+     * @param float $duration
+     * @return string
+     * @throws \Exception
+     */
+    public static function duration_display(float $duration): string {
+        $ms = round($duration * 1000, 0);
+        $s = round($duration, 0);
+        $di = new \DateInterval('PT' . $s . 'S');
+        return $di->format('%i:%S.') . $ms;
+    }
+
+    /**
+     * Returns HTTP status as a badge.
+     *
+     * @param int $status
+     * @return string
+     */
+    public static function http_status_display(int $status): string {
+        $spanclass = 'badge ' . self::STATUS_BADGES[$status / 100];
+        return \html_writer::tag('span', $status, ['class' => $spanclass]);
+    }
+}

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -35,7 +35,7 @@ class helper {
         2 => 'badge-success',
         3 => 'badge-info',
         4 => 'badge-warning',
-        5 => 'badge-error',
+        5 => 'badge-danger',
     ];
 
     /**
@@ -87,10 +87,22 @@ class helper {
      * @throws \Exception
      */
     public static function duration_display(float $duration): string {
-        $ms = round($duration * 1000, 0);
-        $s = round($duration, 0);
-        $di = new \DateInterval('PT' . $s . 'S');
-        return $di->format('%i:%S.') . $ms;
+        $ms = round($duration * 1000, 0) % 1000;
+        $s = (int) $duration;
+        $m = $s / 60;
+        $s = $s % 60;
+        return sprintf('%d:%02d.%3d', $m, $s, $ms);
+    }
+
+    /**
+     * Returns CLI script return status as a badge.
+     *
+     * @param int $status
+     * @return string
+     */
+    public static function cli_return_status_display(int $status): string {
+        $spanclass = 'badge ' . ($status ? 'badge-danger' : 'badge-success');
+        return \html_writer::tag('span', $status, ['class' => $spanclass]);
     }
 
     /**

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -29,13 +29,13 @@ defined('MOODLE_INTERNAL') || die();
 class profile_table extends \table_sql {
 
     const COLUMNS = [
+        'responsecode',
         'request',
         'reason',
         'scripttype',
         'created',
         'duration',
         'user',
-        'responsecode',
         'actions',
     ];
 
@@ -55,6 +55,7 @@ class profile_table extends \table_sql {
             $this->no_sorting($column);
         }
 
+
         $this->set_sql(
             '{tool_excimer_profiles}.id as id, reason, scripttype, request, created, duration, parameters, responsecode,
                      referer, userid, lang, firstname, lastname, firstnamephonetic, lastnamephonetic, middlename, alternatename',
@@ -62,6 +63,7 @@ class profile_table extends \table_sql {
             '1=1'
         );
         $this->define_columns(self::COLUMNS);
+        $this->column_class('duration', 'text-right');
         $this->define_headers($headers);
     }
 
@@ -164,6 +166,8 @@ class profile_table extends \table_sql {
     public function col_responsecode(object $record): string {
         if ($this->is_downloading()) {
             return $record->responsecode;
+        } else if ($record->scripttype == profile::SCRIPTTYPE_CLI) {
+            return helper::cli_return_status_display($record->responsecode);
         } else {
             return helper::http_status_display($record->responsecode);
         }

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -34,10 +34,8 @@ class profile_table extends \table_sql {
         'scripttype',
         'created',
         'duration',
-        'parameters',
         'user',
         'responsecode',
-        'referer',
         'actions',
     ];
 
@@ -65,6 +63,17 @@ class profile_table extends \table_sql {
         );
         $this->define_columns(self::COLUMNS);
         $this->define_headers($headers);
+    }
+
+    /**
+     * Overrides felxible_table::setup() to do some extra setup.
+     *
+     * @return false|\type|void
+     */
+    public function setup() {
+        $retvalue = parent::setup();
+        $this->set_attribute('class', $this->attributes['class'] . ' table-sm');
+        return $retvalue;
     }
 
     /**
@@ -113,7 +122,7 @@ class profile_table extends \table_sql {
      * @return string
      */
     public function col_duration(object $record): string {
-        return format_time($record->duration);
+        return helper::duration_display($record->duration);
     }
 
     /**
@@ -124,17 +133,7 @@ class profile_table extends \table_sql {
      * @throws \coding_exception
      */
     public function col_created(object $record): string {
-        return userdate($record->created, get_string('strftimedatetimeshort', 'langconfig'));
-    }
-
-    /**
-     * Display value for 'parameters' column entries.
-     *
-     * @param object $record
-     * @return string
-     */
-    public function col_parameters(object $record): string {
-        return htmlentities($record->parameters);
+        return userdate($record->created, '%d %b %Y, %H:%M');
     }
 
     /**
@@ -153,6 +152,20 @@ class profile_table extends \table_sql {
             } else {
                 return \html_writer::link('/user/profile.php?id=' . $record->userid, $fullname);
             }
+        }
+    }
+
+    /**
+     * Displays the 'responsecode' column entries
+     *
+     * @param object $record
+     * @return string
+     */
+    public function col_responsecode(object $record): string {
+        if ($this->is_downloading()) {
+            return $record->responsecode;
+        } else {
+            return helper::http_status_display($record->responsecode);
         }
     }
 

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -55,7 +55,6 @@ class profile_table extends \table_sql {
             $this->no_sorting($column);
         }
 
-
         $this->set_sql(
             '{tool_excimer_profiles}.id as id, reason, scripttype, request, created, duration, parameters, responsecode,
                      referer, userid, lang, firstname, lastname, firstnamephonetic, lastnamephonetic, middlename, alternatename',

--- a/classes/profile_table_page.php
+++ b/classes/profile_table_page.php
@@ -59,7 +59,7 @@ class profile_table_page {
 
             if (profile::get_num_profiles() > 0) {
                 $deleteurl = new \moodle_url('/admin/tool/excimer/delete.php', ['deleteall' => true]);
-                $deletebutton = new \single_button($deleteurl, get_string('deleteall', 'tool_excimer'));
+                $deletebutton = new \single_button($deleteurl, get_string('deleteall'));
                 $deletebutton->add_confirm_action(get_string('deleteallwarning', 'tool_excimer'));
                 echo $OUTPUT->render($deletebutton);
             }

--- a/delete.php
+++ b/delete.php
@@ -31,19 +31,18 @@ $returnurl = optional_param('returnurl', get_local_referer(false), PARAM_LOCALUR
 $deleteall = optional_param('deleteall', 0, PARAM_BOOL);
 $deleteid = optional_param('deleteid', 0, PARAM_INT);
 
-if (confirm_sesskey()) {
+require_sesskey();
 
-    // Delete all profiles.
-    if ($deleteall) {
-        $DB->delete_records('tool_excimer_profiles');
-        redirect($returnurl, get_string('allprofiesdeleted', 'tool_excimer'));
-    }
+// Delete all profiles.
+if ($deleteall) {
+    $DB->delete_records('tool_excimer_profiles');
+    redirect($returnurl, get_string('allprofiesdeleted', 'tool_excimer'));
+}
 
-    // Delete profile specified by an ID.
-    if ($deleteid) {
-        $DB->delete_records('tool_excimer_profiles', ['id' => $deleteid]);
-        redirect($returnurl, get_string('profiedeleted', 'tool_excimer'));
-    }
+// Delete profile specified by an ID.
+if ($deleteid) {
+    $DB->delete_records('tool_excimer_profiles', ['id' => $deleteid]);
+    redirect($returnurl, get_string('profiedeleted', 'tool_excimer'));
 }
 
 // Universal graceful fallback.

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -88,7 +88,6 @@ $string['reason_auto'] = 'Auto';
 $string['reason_flameall'] = 'Flame All';
 
 // Miscellaneous.
-$string['deleteall'] = 'Delete all';
 $string['deleteallwarning'] = 'This will remove ALL stored profiles. Continue?';
 $string['deleteprofile'] = 'Delete profile';
 $string['deleteprofilewarning'] = 'This will remove the profile. Continue?';

--- a/profile.php
+++ b/profile.php
@@ -64,7 +64,7 @@ $deletebutton = new \single_button($deleteurl, get_string('deleteprofile', 'tool
 $deletebutton->add_confirm_action(get_string('deleteprofilewarning', 'tool_excimer'));
 
 $data = (array) $profile;
-$data['duration'] = helper::duration_display($data['duration']);
+$data['duration'] = helper::duration_display($profile->duration);
 $data['script_type_display'] = function($text, $render) {
     return helper::script_type_display((int)$render($text));
 };
@@ -73,8 +73,12 @@ $data['reason_display'] = function($text, $render) {
 };
 
 $data['delete_button'] = $OUTPUT->render($deletebutton);
-$data['responsecode'] = helper::http_status_display($data['responsecode']);
 
+if ($profile->scripttype == profile::SCRIPTTYPE_CLI) {
+    $data['responsecode'] = helper::cli_return_status_display($profile->responsecode);
+} else {
+    $data['responsecode'] = helper::http_status_display($profile->responsecode);
+}
 
 if ($user) {
     $data['userlink'] = new moodle_url('/user/profile.php', ['id' => $user->id]);

--- a/profile.php
+++ b/profile.php
@@ -39,9 +39,10 @@ $context = context_system::instance();
 $PAGE->set_context($context);
 $PAGE->set_url($url);
 
-admin_externalpage_setup('tool_excimer_report_slowest');
-
 $returnurl = get_local_referer(false);
+$report = basename($returnurl, '.php');
+
+admin_externalpage_setup('tool_excimer_report_' . $report);
 
 $pluginname = get_string('pluginname', 'tool_excimer');
 
@@ -63,7 +64,7 @@ $deletebutton = new \single_button($deleteurl, get_string('deleteprofile', 'tool
 $deletebutton->add_confirm_action(get_string('deleteprofilewarning', 'tool_excimer'));
 
 $data = (array) $profile;
-$data['duration'] = format_time($data['duration']);
+$data['duration'] = helper::duration_display($data['duration']);
 $data['script_type_display'] = function($text, $render) {
     return helper::script_type_display((int)$render($text));
 };
@@ -72,6 +73,7 @@ $data['reason_display'] = function($text, $render) {
 };
 
 $data['delete_button'] = $OUTPUT->render($deletebutton);
+$data['responsecode'] = helper::http_status_display($data['responsecode']);
 
 
 if ($user) {

--- a/settings.php
+++ b/settings.php
@@ -55,7 +55,7 @@ if ($hassiteconfig) {
         'tool_excimer',
         get_string('pluginname', 'tool_excimer')
     );
-    $ADMIN->add('tools', $settings);
+    $ADMIN->add('tool_excimer_reports', $settings);
 
     if ($ADMIN->fulltree) {
         $warntext = '';

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -96,7 +96,7 @@
         </tr>
         <tr>
             <th>{{#str}} field_responsecode, tool_excimer {{/str}}</th>
-            <td>{{responsecode}}</td>
+            <td>{{{responsecode}}}</td>
         </tr>
         <tr>
             <th>{{#str}} field_referer, tool_excimer {{/str}}</th>


### PR DESCRIPTION
Issue #59
Some breadcrumb fixes.
Moved settings link to development/excimer
Changed delete.php to use require_sesskey().
Removed 'parameter' and 'referer' columns from profile tables.
Added 'table-sm' class to profile tables.
Response codes are displayed as badges.
Duration and created values have new formats.