### PR TITLE
Add support for multiple reasons per profile entry

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -61,23 +61,24 @@ class helper {
     }
 
     /**
-     * Returns a printable string for the profiling reason.
+     * Returns a printable string for the profiling reasons.
      *
      * @param int $reason
      * @return string
      * @throws \coding_exception
      */
     public static function reason_display(int $reason): string {
-        switch ($reason) {
-            case manager::REASON_MANUAL:
-                return get_string('reason_manual', 'tool_excimer');
-            case manager::REASON_AUTO:
-                return get_string('reason_auto', 'tool_excimer');
-            case manager::REASON_FLAMEALL:
-                return get_string('reason_flameall', 'tool_excimer');
-            default:
-                return (string) $reason;
+        $reasonsmatched = [];
+        if ($reason & manager::REASON_AUTO) {
+            $reasonsmatched[] = get_string('reason_auto', 'tool_excimer');
         }
+        if ($reason & manager::REASON_FLAMEALL) {
+            $reasonsmatched[] = get_string('reason_flameall', 'tool_excimer');
+        }
+        if ($reason & manager::REASON_MANUAL) {
+            $reasonsmatched[] = get_string('reason_manual', 'tool_excimer');
+        }
+        return implode(',', $reasonsmatched);
     }
 
     /**

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -55,13 +55,32 @@ class profile_table extends \table_sql {
             $this->no_sorting($column);
         }
 
+        $fields = [
+            '{tool_excimer_profiles}.id as id',
+            'reason',
+            'scripttype',
+            'method',
+            'request',
+            'pathinfo',
+            'created',
+            'duration',
+            'parameters',
+            'responsecode',
+            'referer',
+            'userid',
+            'lang',
+            'firstname',
+            'lastname',
+            'firstnamephonetic',
+            'lastnamephonetic',
+            'middlename',
+            'alternatename',
+        ];
+        $fieldsstr = implode(',', $fields);
         $this->set_sql(
-            '{tool_excimer_profiles}.id as id, reason, scripttype, method, request, pathinfo, created,
-                     duration, parameters, responsecode, referer, userid, lang, firstname, lastname, firstnamephonetic,
-                     lastnamephonetic, middlename, alternatename',
-            '{tool_excimer_profiles} LEFT JOIN {user} on ({tool_excimer_profiles}.userid = {user}.id)',
-            '1=1'
-        );
+                $fieldsstr,
+                '{tool_excimer_profiles} LEFT JOIN {user} ON {user}.id = {tool_excimer_profiles}.userid',
+                '1=1');
         $this->define_columns(self::COLUMNS);
         $this->column_class('responsecode', 'text-right');
         $this->column_class('duration', 'text-right');


### PR DESCRIPTION
- Simplify output (using implode).
- Simplify storage, removing unnecessary flag setting and checking
- Did NOT touch existing purge tasks, as anything not purely captured
  via automatic means should not be automatically purged even if it met
  the conditions.
- phpcs: Fix trailing whitespace.
- Fix array whitespacing for more consistency.
- phpcs: Fix long line > 132 characters for set_sql call.

Preview:

![image](https://user-images.githubusercontent.com/9924643/146313434-2dbd0553-d0dd-4700-9079-ba4a9b836390.png)


Closes #64 