### PR TITLE
Add params to the request field similar to GET requests #87

### DIFF
--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -112,6 +112,7 @@ class profile_table extends \table_sql {
             if ($record->scripttype == profile::SCRIPTTYPE_CLI) {
                 // For CLI scripts, request should look like `command.php --flag=value` as an example.
                 $separator = ' ';
+                $record->parameters = escapeshellcmd($record->parameters);
             } else {
                 // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
                 $separator = '?';

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -108,15 +108,25 @@ class profile_table extends \table_sql {
      */
     public function col_request(object $record): string {
         $displayedrequest = $record->request . $record->pathinfo;
-        if ($record->method === 'GET' && !empty($record->parameters)) {
-            $displayedrequest .= '?' . urldecode($record->parameters);
+        if (!empty($record->parameters)) {
+            if ($record->scripttype == profile::SCRIPTTYPE_CLI) {
+                // For CLI scripts, request should look like `command.php --flag=value` as an example.
+                $separator = ' ';
+            } else {
+                // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
+                $separator = '?';
+                $record->parameters = urldecode($record->parameters);
+            }
+            $displayedrequest .= $separator . $record->parameters;
         }
 
+        // Return plaintext for download table response format.
         if ($this->is_downloading()) {
-            return $displayedrequest;
+            return $record->method . ' ' . $displayedrequest;
         }
 
-        return \html_writer::link(
+        // Return the web format.
+        return $record->method . ' ' . \html_writer::link(
                 new \moodle_url('/admin/tool/excimer/profile.php', ['id' => $record->id]),
                 shorten_text($displayedrequest, 100, true, '…'),
                 ['title' => $displayedrequest, 'style' => 'word-break: break-all']);

--- a/profile.php
+++ b/profile.php
@@ -70,12 +70,22 @@ $data = (array) $profile;
 $data['duration'] = format_time($data['duration']);
 
 $data['request'] = $profile->request . $profile->pathinfo;
-if ($profile->method === 'GET' && !empty($profile->parameters)) {
-    $data['request'] .= '?' . htmlentities($profile->parameters);
+if (!empty($profile->parameters)) {
+    $parameters = $profile->parameters;
+    if ($profile->scripttype == profile::SCRIPTTYPE_CLI) {
+        // For CLI scripts, request should look like `command.php --flag=value` as an example.
+        $separator = ' ';
+    } else {
+        // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
+        $separator = '?';
+        $parameters = urldecode($parameters);
+    }
+    $data['request'] .= $separator . $parameters;
 }
+
 // If GET request then it should be reproducable as a idempotent request (readonly).
 if ($profile->method === 'GET') {
-    $requesturl = new \moodle_url('/' . $data['request']);
+    $requesturl = new \moodle_url('/' . $profile->request . $profile->pathinfo . '?' . htmlentities($profile->parameters));
     $data['request'] = \html_writer::link(
             $requesturl,
             urldecode($data['request']),

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -61,7 +61,7 @@
     <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
         <tr>
             <th>{{#str}} field_request, tool_excimer {{/str}}</th>
-            <td>{{{request}}}</td>
+            <td>{{{responsecode}}} {{method}} {{{request}}}</td>
         </tr>
         <tr>
             <th>{{#str}} field_sessionid, tool_excimer {{/str}}</th>
@@ -87,10 +87,6 @@
             <th>{{#str}} field_user, tool_excimer {{/str}}</th>
             <td>{{#userlink}}<a href="{{userlink}}">{{fullname}}</a>{{/userlink}}
                 {{^userlink}}{{fullname}}{{/userlink}}</td>
-        </tr>
-        <tr>
-            <th>{{#str}} field_responsecode, tool_excimer {{/str}}</th>
-            <td>{{{responsecode}}}</td>
         </tr>
         <tr>
             <th>{{#str}} field_cookies, tool_excimer {{/str}}</th>


### PR DESCRIPTION
Few screenshots of changed display for CLI commands

Profile

![image](https://user-images.githubusercontent.com/9924643/146496128-e5c409ff-8793-458b-82fe-ceaf394c4961.png)

List 

![image](https://user-images.githubusercontent.com/9924643/146496089-2b6f1995-25e4-4099-ba70-42f1e7d78f43.png)

CLI list

![image](https://user-images.githubusercontent.com/9924643/146496180-d285e7aa-2554-45e3-83cb-24120664d38d.png)

CLI profile

![image](https://user-images.githubusercontent.com/9924643/146496194-6bdacc9e-730a-4873-a475-c32dd87a671f.png)

**Note: The example won't work as a copy and paste due to the fact it's using `\` and it won't be properly escaped e.g. in bash without wrapping the value in quotes or using double back slash.**

Closes #87 
Closes #86