### PR TITLE
Add new fields to hold detected content type of the request #61

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -18,6 +18,8 @@ namespace tool_excimer;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core_filetypes;
+
 /**
  * Helpers for displaying stuff.
  *
@@ -116,4 +118,82 @@ class helper {
         $spanclass = 'badge ' . self::STATUS_BADGES[$status / 100];
         return \html_writer::tag('span', $status, ['class' => $spanclass]);
     }
+
+    /**
+     * Checks the current response headers and tries to resolve the content type
+     * e.g. to store as part of the profile.
+     *
+     * @param      string $request the request of the profile to be stored.
+     * @param      string $pathinfo the pathinfo of the profile to be stored.
+     * @return     array containing [value, key, category]
+     *                   Where:
+     *                   - value is the raw content type detected,
+     *                   - key is the resolved filetype key or if not found, the
+     *                     detected extension.
+     *                   - category the general group it should fall under.
+     * @author     Kevin Pham <kevinpham@catalyst-au.net>
+     * @copyright  Catalyst IT, 2021
+     */
+    public static function resolve_content_type(string $request, string $pathinfo) {
+        $contenttypevalue = null;
+        $contenttypekey = null;
+        $contenttypecategory = null;
+
+        // Get 'Content-Type' header to perform further checks.
+        $headers = headers_list();
+        if (!empty($headers)) {
+            foreach ($headers as $header) {
+                $index = strpos(strtolower($header), 'content-type');
+                if ($index === 0) {
+                    list($contenttypewhole) = explode(';', $header, 2);
+                    list(, $contenttypevalue) = explode(': ', $contenttypewhole, 2);
+                    break;
+
+                }
+            }
+        }
+
+        // If there is no Content-Type header detected, then bail since we
+        // aren't sure - it could be coming from CLI and thus needs no response
+        // headers, but the content type could vary (text/image) and there is no
+        // other checks for it at the moment.
+        // TODO: Should this check and prefill CLI based requests?
+
+        // Compare the value of 'Content-Type' to known values, to determine the content type fields.
+        $allfiletypes = core_filetypes::get_types();
+        // NOTE: This will stop on the FIRST match based on this list. It
+        // will also use the 'key' if the 'string' is not available.
+        foreach ($allfiletypes as $key => $filetype) {
+            if ($filetype['type'] === $contenttypevalue) {
+                $contenttypekey = $key;
+                $contenttypecategory = $filetype['string'] ?? $key;
+                break;
+            }
+        }
+
+        // If it cannot be determined via the core_filetypes, determine it based
+        // on known groups e.g. font.php, javascript.php, handlers, etc.
+        if (empty($contenttypekey)) {
+            $requestbasename = basename($request);
+            if (
+                $contenttypevalue === 'application/javascript' // Common, but not in filetypes as this exactly.
+                || $requestbasename === 'javascript.php'
+            ) {
+                $contenttypekey = 'js';
+                $contenttypecategory = 'js';
+            } else if ($requestbasename === 'font.php') {
+                list(, $trailingpathinfo) = explode('.', $pathinfo, 2);
+                list($extension) = explode('?', $trailingpathinfo, 2);
+
+                // Use the extension of the request to determine the 'key' (more
+                // or less analogous to the expected file extension anyways).
+                $contenttypekey = $extension;
+                $contenttypecategory = 'font';
+            }
+        }
+
+        return [$contenttypevalue, $contenttypekey, $contenttypecategory];
+    }
+
+
 }

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -194,6 +194,8 @@ class profile {
         $request = isset($SCRIPT) ? ltrim($SCRIPT, '/') : self::REQUEST_UNKNOWN;
         $pathinfo = $_SERVER['PATH_INFO'] ?? '';
 
+        list($contenttypevalue, $contenttypekey, $contenttypecategory) = helper::resolve_content_type($request, $pathinfo);
+
         return $DB->insert_record('tool_excimer_profiles', [
             'sessionid' => substr(session_id(), 0, 10),
             'reason' => $reason,
@@ -212,6 +214,9 @@ class profile {
             'datasize' => $datasize,
             'numsamples' => $numsamples,
             'flamedatad3' => $flamedatad3json,
+            'contenttypevalue' => $contenttypevalue,
+            'contenttypekey' => $contenttypekey,
+            'contenttypecategory' => $contenttypecategory,
         ]);
     }
 

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -32,7 +32,7 @@ class profile_table extends \table_sql {
         'responsecode',
         'request',
         'reason',
-        'scripttype',
+        'type',
         'created',
         'duration',
         'user',
@@ -104,6 +104,7 @@ class profile_table extends \table_sql {
             '{tool_excimer_profiles}.id as id',
             'reason',
             'scripttype',
+            'contenttypecategory',
             'method',
             'request',
             'pathinfo',
@@ -161,8 +162,26 @@ class profile_table extends \table_sql {
      * @return string
      * @throws \coding_exception
      */
-    public function col_scripttype(object $record): string {
-        return helper::script_type_display($record->scripttype);
+    public function col_type(object $record): string {
+        $scripttype = helper::script_type_display($record->scripttype);
+        $contenttype = $record->contenttypecategory;
+
+        // Wrap fields in span which more accurately describes them on hover.
+        if (!$this->is_downloading()) {
+            $scripttype = \html_writer::span(
+                    $scripttype,
+                    '',
+                    ['title' => get_string('field_scripttype', 'tool_excimer')]);
+            $contenttype = \html_writer::span(
+                    $contenttype,
+                    '',
+                    ['title' => get_string('field_contenttypecategory', 'tool_excimer')]);
+        }
+
+        return implode(' - ', [
+            $scripttype,
+            $contenttype,
+        ]);
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -24,6 +24,9 @@
         <FIELD NAME="datasize" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Size of the profile data (in bytes)"/>
         <FIELD NAME="numsamples" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Number of samples taken"/>
         <FIELD NAME="flamedatad3" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="JSON structure compatible with d3-flame-graph."/>
+        <FIELD NAME="contenttypecategory" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="core_filetypes' resolved string value"/>
+        <FIELD NAME="contenttypekey" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="core_filetypes's key from the types available."/>
+        <FIELD NAME="contenttypevalue" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="Raw content type as returned from the content-type response header, if available"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -58,6 +58,7 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         // Excimer savepoint reached.
         upgrade_plugin_savepoint(true, 2021121700, 'tool', 'excimer');
     }
+
     if ($oldversion < 2021122000) {
         $table = new xmldb_table('tool_excimer_profiles');
 
@@ -79,6 +80,39 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         }
 
         upgrade_plugin_savepoint(true, 2021122000, 'tool', 'excimer');
+    }
+
+    if ($oldversion < 2021122001) {
+
+        // Define field contenttypecategory to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('contenttypecategory', XMLDB_TYPE_CHAR, '30', null, null, null, null, 'flamedatad3');
+
+        // Conditionally launch add field contenttypecategory.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field contenttypekey to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('contenttypekey', XMLDB_TYPE_CHAR, '30', null, null, null, null, 'contenttypecategory');
+
+        // Conditionally launch add field contenttypekey.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field contenttypevalue to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('contenttypevalue', XMLDB_TYPE_CHAR, '30', null, null, null, null, 'contenttypekey');
+
+        // Conditionally launch add field contenttypevalue.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2021122001, 'tool', 'excimer');
     }
 
     return true;

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -59,7 +59,12 @@ $string['slowest'] = 'Slowest';
 
 // Profile table.
 $string['field_id'] = 'ID';
-$string['field_scripttype'] = 'Type';
+$string['field_type'] = 'Type';
+$string['field_scripttype'] = 'Script Type';
+$string['field_contenttype'] = 'Content Type';
+$string['field_contenttypecategory'] = 'Content Type (category)';
+$string['field_contenttypekey'] = 'Content Type (extension/key)';
+$string['field_contenttypevalue'] = 'Content Type (actual value)';
 $string['field_reason'] = 'Reason';
 $string['field_created'] = 'Created';
 $string['field_user'] = 'User';

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -65,6 +65,16 @@
             <td>{{{responsecode}}} {{method}} {{{request}}}</td>
         </tr>
         <tr>
+            <th>{{#str}} field_contenttype, tool_excimer {{/str}}</th>
+            <td>
+                <span title="{{#str}} field_contenttypecategory, tool_excimer {{/str}}">{{contenttypecategory}}</span>
+                -
+                <span title="{{#str}} field_contenttypekey, tool_excimer {{/str}}">.{{contenttypekey}}</span>
+                -
+                <span title="{{#str}} field_contenttypevalue, tool_excimer {{/str}}">{{contenttypevalue}}</span>
+            </td>
+        </tr>
+        <tr>
             <th>{{#str}} field_sessionid, tool_excimer {{/str}}</th>
             <td>{{sessionid}}...</td>
         </tr>

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021122000;
-$plugin->release = 2021122000;
+$plugin->version = 2021122001;
+$plugin->release = 2021122001;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
- Helper function to resolve most content types, can be extended if
  needed.
- Added single field to profile page listing all 3 levels of content
  type (value, key/extension and category)
- Added field under the type column on the list page, which was used for
  scripts and now displays both.

Screenshots of changes:

![image](https://user-images.githubusercontent.com/9924643/146720910-c9402112-b80c-48b7-88aa-039bcf0a8d79.png)

![image](https://user-images.githubusercontent.com/9924643/146720956-031322bb-927f-4014-ab89-e507c099c6d8.png)
