### PR TITLE
Optimise profiler storage based on cached durations (#121, #106)

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -217,7 +217,7 @@ class manager {
             $result[$cachefield] = $minduration;
             $cache->set($cachekey, $result);
         }
-        return $result[$cachefield];
+        return (float)$result[$cachefield];
     }
 
     /**
@@ -252,7 +252,7 @@ class manager {
             $result = (end($resultset)->min_duration ?? 0) * 1000;
             set_config($cachekey, $result, 'tool_excimer');
         }
-        return $result;
+        return (float)$result;
     }
 
     /**
@@ -299,6 +299,20 @@ class manager {
         return true;
     }
 
+    /**
+     * Clears the plugin cache for keys used for the provided reasons
+     *
+     * @param int $reason bitmap of reason(s)
+     */
+    public static function clear_min_duration_cache_for_reason(int $reason): void {
+        foreach (self::REASONS as $basereason) {
+            if ($reason & $basereason) {
+                // Clear the plugin config cache for this profile's reason.
+                $cachekey = 'profile_type_' . $basereason . '_min_duration_ms';
+                unset_config($cachekey, 'tool_excimer');
+            }
+        }
+    }
 
     /**
      * Called when the Excimer log flushes.

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -273,14 +273,14 @@ class manager {
         // First, check against the trigger_ms value to ensure it meets the
         // minimum required duration for the profile to be considered slow.
         $triggerms = get_config('tool_excimer', 'trigger_ms');
-        if ($triggerms && $duration < $triggerms) {
+        if ($triggerms && $duration <= $triggerms) {
             return false;
         }
 
         // If a min duration exists, it means the quota is filled, and only
         // profiles slower than the fastest stored profile should be stored.
         $minduration = self::get_min_duration_for_reason(self::REASON_SLOW);
-        if ($minduration && $duration < $minduration) {
+        if ($minduration && $duration <= $minduration) {
             return false;
         }
 
@@ -290,7 +290,7 @@ class manager {
         // profiles slower than the fastest stored profile should be stored.
         $request = profile::get_request();
         $requestminduration = self::get_min_duration_for_request_and_reason($request, self::REASON_SLOW);
-        if ($requestminduration && $duration < $requestminduration) {
+        if ($requestminduration && $duration <= $requestminduration) {
             return false;
         }
 

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -168,7 +168,8 @@ class manager {
         if (isset($SESSION->toolexcimerflameall)) {
             $reason |= self::REASON_FLAMEALL;
         }
-        if (($duration * 1000) >= self::get_min_duration_for_reason_slow()) {
+
+        if (self::is_considered_slow($duration * 1000)) {
             $reason |= self::REASON_SLOW;
         }
         return $reason;
@@ -176,6 +177,9 @@ class manager {
 
     /**
      * Returns the minimum duration for profiles matching this reason and page/request.
+     *
+     * Cost: 1 cache read (ideally)
+     * Otherwise: 1 cache read, 1 DB read and 1 cache write.
      *
      * @param  int $reason - the profile type or REASON_*
      * @return float duration (in milliseconds) of the fastest profile for a given reason and request/page.
@@ -188,10 +192,11 @@ class manager {
 
         // Grab the fastest profile for this page/request, and use that as
         // the lower boundary for any new profiles of this page/request.
-        $cachekey = "profile_type_$reason" . "_page_$request" . '_min_duration_ms';
-        $cache = \cache::make('tool_excimer', 'timings');
+        $cachekey = $request;
+        $cachefield = "min_duration_for_reason_$reason";
+        $cache = \cache::make('tool_excimer', 'request_metadata');
         $result = $cache->get($cachekey);
-        if ($result === false) {
+        if ($result === false || !isset($result[$cachefield])) {
             // NOTE: Opting to query this way instead of using MIN due to
             // the fact valid profiles will be added and the limits will be
             // breached for 'some time'. This will keep the constraints as
@@ -206,16 +211,20 @@ class manager {
             $resultset = $DB->get_records_sql($sql, [
                 self::REASON_NONE,
                 $request,
-            ], 0, $pagequota);
+            ], $pagequota - 1, 1); // Will fetch the Nth item based on the quota.
             // Cache the results in milliseconds (avoids recalculation later).
-            $result = (end($resultset)->min_duration ?? 0) * 1000;
+            $minduration = (end($resultset)->min_duration ?? 0) * 1000;
+            $result[$cachefield] = $minduration;
             $cache->set($cachekey, $result);
         }
-        return $result;
+        return $result[$cachefield];
     }
 
     /**
      * Returns the minimum duration for profiles matching this reason.
+     *
+     * Cost: Should be free as long as the cache exists in the config.
+     * Otherwise: 1 DB read, 1 cache write
      *
      * @param  int $reason - the profile type or REASON_*
      * @return float duration (in milliseconds) of the fastest profile for a given reason.
@@ -225,11 +234,9 @@ class manager {
 
         $reasonstr = self::REASON_STR_MAP[$reason];
         $quota = (int) get_config('tool_excimer', "num_$reasonstr");
-        $cache = \cache::make('tool_excimer', 'timings');
-        // Grab the fastest profile across the slow profiles, and use that
-        // as the lower boundary for any new profiles.
-        $cachekey = "profile_type_$reason" . '_min_duration_ms';
-        $result = $cache->get($cachekey);
+
+        $cachekey = 'profile_type_' . $reason . '_min_duration_ms';
+        $result = get_config('tool_excimer', $cachekey);
         if ($result === false) {
             // Get and set cache.
             $reasons = $DB->sql_bitand('reason', $reason);
@@ -240,115 +247,56 @@ class manager {
                      ";
             $resultset = $DB->get_records_sql($sql, [
                 self::REASON_NONE,
-            ], 0, $quota);
+            ], $quota - 1, 1); // Will fetch the Nth item based on the quota.
             // Cache the results in milliseconds (avoids recalculation later).
             $result = (end($resultset)->min_duration ?? 0) * 1000;
-            $cache->set($cachekey, $result);
+            set_config($cachekey, $result, 'tool_excimer');
         }
         return $result;
     }
 
     /**
-     * Quota for this profile type (e.g. REASON_SLOW) has been reached.
+     * Returns whether or not the profile should be stored based on the duration provided.
      *
-     * @param int reason
-     * @return bool whether or not the quota is filled.
+     * The order in which items are checked are based on the cost of those
+     * checks, with get_config related calls considered free, cache api being
+     * slightly more expensive and DB calls being the most expensive.
+     *
+     * The order is also based on the fact most things should NOT be captured as
+     * it should be harder to reach the minimums required for a new profile to
+     * be stored once quotas are maxed.
+     *
+     * @param float duration of the current profile
+     * @return bool whether or not the profile should stored with the REASON_AUTO reason.
      */
-    public static function has_filled_reason_quota(int $reason): bool {
-        global $DB;
-
-        $reasonstr = self::REASON_STR_MAP[$reason];
-        $quota = (int) get_config('tool_excimer', "num_$reasonstr");
-
-        // Get and set cache.
-        $reasons = $DB->sql_bitand('reason', $reason);
-        $sql = "SELECT count(*)
-                  FROM {tool_excimer_profiles}
-                 WHERE $reasons != ?";
-        $count = $DB->count_records_sql($sql, [
-            self::REASON_NONE,
-        ]);
-        return $count >= $quota;
-    }
-
-    /**
-     * Quota for this page, for this profile type (e.g. REASON_SLOW) has been reached.
-     *
-     * @param int reason
-     * @return bool whether or not the quota is filled.
-     */
-    public static function has_filled_page_and_reason_quota(string $request, int $reason): bool {
-        global $DB;
-        $reasonstr = self::REASON_STR_MAP[$reason];
-        $quota = (int) get_config('tool_excimer', "num_' . $reasonstr . '_by_page");
-
-        // Get and set cache.
-        $reasons = $DB->sql_bitand('reason', $reason);
-        $sql = "SELECT count(*)
-                  FROM {tool_excimer_profiles}
-                 WHERE $reasons != ?
-                       AND request = ?";
-        $count = $DB->count_records_sql($sql, [
-            self::REASON_NONE,
-            $request,
-        ]);
-        return $count >= $quota;
-    }
-
-    /**
-     * Checks the quotas, and returns the best value for the min duration a
-     * profile should be, before it should be saved.
-     *
-     * This will check quotass per page first, then check the more broad quotas, because it only
-     * matters if the page quota has been exceeded, e.g. after the broad quota
-     * has been reached.
-     *
-     * Assuming limits of page=5 and overall=10 (unlikely to be less than the
-     * page quota). The following behaviour is based on this assumption, that
-     * the page limit is less than the other limit (the reason limit or overall
-     * limit in this example).
-     *
-     * With all examples, the check should look at the profile duration based on
-     * the quota that's filled, and if both are filled then it should look at
-     * the pagequota values before adding a new profile.
-     *
-     * Examples:
-     * [quota filled, pagequota filled]:
-     * Should look and add new profiles based on pagequota, as this is the limiting factor before it can be saved.
-     *
-     * [quota filled, pagequota notfilled]:
-     * Should be based on (overall) quota filled.
-     *
-     * [quota notfilled, pagequota filled]:
-     * Should be based on the page quota.
-     *
-     * [quota notfilled, pagequota notfilled]:
-     * Should be based on configuration thresholds/limits.
-     *
-     * @return float the minimum duration required, for a profile to be stored with the REASON_AUTO reason.
-     */
-    public static function get_min_duration_for_reason_slow(): float {
-        // Quota for this page, for this profile type (e.g. REASON_SLOW) has been reached.
-        $request = profile::get_request();
-
-        // Get the cached timings for the fastest of the stored profiles, to
-        // ensure anything faster than this does not get stored iif the quota is
-        // reached. This cache should be reset when, a new profile is
-        // stored/deleted, or settings have changed.
-        if (self::has_filled_page_and_reason_quota($request, self::REASON_AUTO)) {
-            // Quota for this profile type (e.g. REASON_SLOW) for this page/request has been reached.
-            $result = self::get_min_duration_for_request_and_reason($request, self::REASON_AUTO);
-        } else if (self::has_filled_reason_quota(self::REASON_AUTO)) {
-            // Quota for this profile type (e.g. REASON_SLOW) has been reached.
-            $result = self::get_min_duration_for_reason(self::REASON_AUTO);
+    public static function is_considered_slow(float $duration): bool {
+        // First, check against the trigger_ms value to ensure it meets the
+        // minimum required duration for the profile to be considered slow.
+        $triggerms = get_config('tool_excimer', 'trigger_ms');
+        if ($triggerms && $duration < $triggerms) {
+            return false;
         }
 
-        // Between the config and the fastest stored profile flagged for being
-        // slow, grab the slower option as that is the new minimum (#106).
-        $triggerms = (int) get_config('tool_excimer', 'trigger_ms');
-        $minduration = max($triggerms, $result ?? 0);
+        // If a min duration exists, it means the quota is filled, and only
+        // profiles slower than the fastest stored profile should be stored.
+        $minduration = self::get_min_duration_for_reason(self::REASON_AUTO);
+        if ($minduration && $duration < $minduration) {
+            return false;
+        }
 
-        return $minduration;
+        // This is reached if the duration provided should be checked with the
+        // request minimum.
+        // If a min duration exists, it means the quota is filled, and only
+        // profiles slower than the fastest stored profile should be stored.
+        $request = profile::get_request();
+        $requestminduration = self::get_min_duration_for_request_and_reason($request, self::REASON_AUTO);
+        if ($requestminduration && $duration < $requestminduration) {
+            return false;
+        }
+
+        // By this stage, the duration provided should have exceeded the min
+        // requirements for all the different timing types (if they exist).
+        return true;
     }
 
 

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -53,7 +53,7 @@ class manager {
 
     const REASON_STR_MAP = [
         self::REASON_MANUAL => 'manual',
-        self::REASON_AUTO => 'slowest',
+        self::REASON_SLOW => 'slowest',
         self::REASON_FLAMEALL => 'flameall',
     ];
 
@@ -267,7 +267,7 @@ class manager {
      * be stored once quotas are maxed.
      *
      * @param float duration of the current profile
-     * @return bool whether or not the profile should stored with the REASON_AUTO reason.
+     * @return bool whether or not the profile should stored with the REASON_SLOW reason.
      */
     public static function is_considered_slow(float $duration): bool {
         // First, check against the trigger_ms value to ensure it meets the
@@ -279,7 +279,7 @@ class manager {
 
         // If a min duration exists, it means the quota is filled, and only
         // profiles slower than the fastest stored profile should be stored.
-        $minduration = self::get_min_duration_for_reason(self::REASON_AUTO);
+        $minduration = self::get_min_duration_for_reason(self::REASON_SLOW);
         if ($minduration && $duration < $minduration) {
             return false;
         }
@@ -289,7 +289,7 @@ class manager {
         // If a min duration exists, it means the quota is filled, and only
         // profiles slower than the fastest stored profile should be stored.
         $request = profile::get_request();
-        $requestminduration = self::get_min_duration_for_request_and_reason($request, self::REASON_AUTO);
+        $requestminduration = self::get_min_duration_for_request_and_reason($request, self::REASON_SLOW);
         if ($requestminduration && $duration < $requestminduration) {
             return false;
         }

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -35,7 +35,7 @@ class manager {
     /** Reason - MANUAL - Profiles are manually stored for the request using FLAMEME as a page param. */
     const REASON_MANUAL   = 0b0001;
 
-    /** Reason - AUTO - Set when conditions are met and these profiles are automatically stored. */
+    /** Reason - SLOW - Set when conditions are met and these profiles are automatically stored. */
     const REASON_SLOW     = 0b0010;
 
     /** Reason - FLAMEALL - Toggles profiling for all subsequent pages, until FLAMEALLSTOP param is passed as a page param. */

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -188,7 +188,7 @@ class manager {
         global $DB;
 
         $reasonstr = self::REASON_STR_MAP[$reason];
-        $pagequota = (int) get_config('tool_excimer', "num_' . $reasonstr . '_by_page");
+        $pagequota = (int) get_config('tool_excimer', 'num_' . $reasonstr . '_by_page');
 
         // Grab the fastest profile for this page/request, and use that as
         // the lower boundary for any new profiles of this page/request.

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -283,9 +283,9 @@ class profile {
             $db2->dispose();
         }
 
-        // Clear the profile request_metadata cache on insert/update of a profile.
+        // Clear the request_metadata cache for the specific request.
         $cache = \cache::make('tool_excimer', 'request_metadata');
-        $cache->purge();
+        $cache->delete($request);
 
         return $id;
     }
@@ -339,9 +339,12 @@ class profile {
         }
 
         if ($updateordelete) {
-            // Clear the profile request_metadata cache on insert/update of a profile.
+            // Clear the request_metadata cache on insert/updates for affected profile requests.
             $cache = \cache::make('tool_excimer', 'request_metadata');
-            $cache->purge();
+            $requests = array_column($profiles, 'request');
+            // Note: Slightly faster than array_unique since the values can be used as keys.
+            $uniquerequests = array_flip(array_flip($requests));
+            $cache->delete_many($uniquerequests);
         }
     }
 

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -283,8 +283,8 @@ class profile {
             $db2->dispose();
         }
 
-        // Clear the profile timings cache on insert/update of a profile.
-        $cache = \cache::make('tool_excimer', 'timings');
+        // Clear the profile request_metadata cache on insert/update of a profile.
+        $cache = \cache::make('tool_excimer', 'request_metadata');
         $cache->purge();
 
         return $id;
@@ -339,8 +339,8 @@ class profile {
         }
 
         if ($updateordelete) {
-            // Clear the profile timings cache on insert/update of a profile.
-            $cache = \cache::make('tool_excimer', 'timings');
+            // Clear the profile request_metadata cache on insert/update of a profile.
+            $cache = \cache::make('tool_excimer', 'request_metadata');
             $cache->purge();
         }
     }

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -211,6 +211,7 @@ class profile {
         $flamedatad3json = json_encode($flamedatad3);
         $flamedatad3gzip = gzcompress($flamedatad3json);
         $datasize = strlen($flamedatad3gzip);
+        $request = self::get_request();
 
         $intrans = $DB->is_transaction_started();
 
@@ -234,7 +235,6 @@ class profile {
             $method = $_SERVER['REQUEST_METHOD'] ?? '';
 
             // If set, it will trim off the leading '/' to normalise web & cli requests.
-            $request = self::get_request();
             $pathinfo = $_SERVER['PATH_INFO'] ?? '';
 
             list($contenttypevalue, $contenttypekey, $contenttypecategory) = helper::resolve_content_type($request, $pathinfo);

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -283,9 +283,20 @@ class profile {
             $db2->dispose();
         }
 
+        // NOTE: Does clearing the cache on partial saves make sense? The cache
+        // currently sets the min duration for how long a profile should go for
+        // before it gets stored, for other reasons later on, it might be
+        // pushing on additional constraints. In either case, clearing the cache
+        // here assumes a few things: 1 - quota has been reached, 2 - minimum duration
+        // will have changed, typically higher. 3 - every partial save will
+        // cause some sort of reordering and potentially the cached items won't
+        // hold correct values.
+
         // Clear the request_metadata cache for the specific request.
         $cache = \cache::make('tool_excimer', 'request_metadata');
         $cache->delete($request);
+        // Clears the set_config cache for the affected reasons.
+        manager::clear_min_duration_cache_for_reason($reason);
 
         return $id;
     }
@@ -345,6 +356,7 @@ class profile {
             // Note: Slightly faster than array_unique since the values can be used as keys.
             $uniquerequests = array_flip(array_flip($requests));
             $cache->delete_many($uniquerequests);
+            manager::clear_min_duration_cache_for_reason($reason);
         }
     }
 

--- a/db/caches.php
+++ b/db/caches.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $definitions = array(
-    'timings' => array(
+    'request_metadata' => array(
         'mode' => cache_store::MODE_APPLICATION,
         'simplekeys' => false,
         'simpledata' => true,

--- a/db/caches.php
+++ b/db/caches.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cache definitions.
+ *
+ * @package    tool_excimer
+ * @author     Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright  Catalyst IT, 2021
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$definitions = array(
+    'timings' => array(
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => false,
+        'simpledata' => true,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 10,
+        'canuselocalstore' => false
+    ),
+);

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -116,6 +116,7 @@ $string['reason_flameall'] = 'Flame All';
 $string['strftime_datetime'] = '%d %b %Y, %H:%M';
 
 // Miscellaneous.
+$string['cachedef_request_metadata'] = 'Excimer request metadata cache';
 $string['deleteallwarning'] = 'This will remove ALL stored profiles. Continue?';
 $string['deleteprofile'] = 'Delete profile';
 $string['deleteprofilewarning'] = 'This will remove the profile. Continue?';

--- a/settings.php
+++ b/settings.php
@@ -40,7 +40,7 @@ if ($hassiteconfig) {
     if ($ADMIN->fulltree) {
 
         // Ensure if particular setting(s) are updated, the cache for profile
-        // timings is cleared, at at most once.
+        // timings is cleared, at most once.
         $clearprofiletimingscachecallback = function() {
             static $called = false;
             if (!$called) {

--- a/settings.php
+++ b/settings.php
@@ -40,13 +40,13 @@ if ($hassiteconfig) {
     if ($ADMIN->fulltree) {
 
         // Ensure if particular setting(s) are updated, the cache for profile
-        // timings is cleared, at most once.
+        // request metadata is cleared, at most once.
         $clearprofiletimingscachecallback = function() {
             static $called = false;
             if (!$called) {
                 $called = true;
-                // Clear the profile timings cache on insert/update of a profile.
-                $cache = \cache::make('tool_excimer', 'timings');
+                // Clear the profile request_metadata caches.
+                $cache = \cache::make('tool_excimer', 'request_metadata');
                 $cache->purge();
             }
         };

--- a/settings.php
+++ b/settings.php
@@ -38,6 +38,19 @@ if ($hassiteconfig) {
     $ADMIN->add('tool_excimer_reports', $settings);
 
     if ($ADMIN->fulltree) {
+
+        // Ensure if particular setting(s) are updated, the cache for profile
+        // timings is cleared, at at most once.
+        $clearprofiletimingscachecallback = function() {
+            static $called = false;
+            if (!$called) {
+                $called = true;
+                // Clear the profile timings cache on insert/update of a profile.
+                $cache = \cache::make('tool_excimer', 'timings');
+                $cache->purge();
+            }
+        };
+
         $warntext = '';
         if (!class_exists('ExcimerProfiler')) {
             $packageinstallurl = new \moodle_url('https://github.com/catalyst/moodle-tool_excimer#installation');
@@ -95,35 +108,36 @@ if ($hassiteconfig) {
             )
         );
 
-        $settings->add(
-            new admin_setting_configtext(
-                'tool_excimer/trigger_ms',
-                get_string('request_ms', 'tool_excimer'),
-                get_string('request_ms_desc', 'tool_excimer'),
-                '100',
-                PARAM_INT
-            )
+        $item = new admin_setting_configtext(
+            'tool_excimer/trigger_ms',
+            get_string('request_ms', 'tool_excimer'),
+            get_string('request_ms_desc', 'tool_excimer'),
+            '100',
+            PARAM_INT
         );
+        $item->set_updatedcallback($clearprofiletimingscachecallback);
+        $settings->add($item);
 
-        $settings->add(
-            new admin_setting_configtext(
-                'tool_excimer/num_slowest',
-                get_string('num_slowest', 'tool_excimer'),
-                get_string('num_slowest_desc', 'tool_excimer'),
-                '100',
-                PARAM_INT
-            )
+        $item = new admin_setting_configtext(
+            'tool_excimer/num_slowest',
+            get_string('num_slowest', 'tool_excimer'),
+            get_string('num_slowest_desc', 'tool_excimer'),
+            '100',
+            PARAM_INT
         );
+        $item->set_updatedcallback($clearprofiletimingscachecallback);
+        $settings->add($item);
 
-        $settings->add(
-            new admin_setting_configtext(
-                'tool_excimer/num_slowest_by_page',
-                get_string('num_slowest_by_page', 'tool_excimer'),
-                get_string('num_slowest_by_page_desc', 'tool_excimer'),
-                '5',
-                PARAM_INT
-            )
+        $item = new admin_setting_configtext(
+            'tool_excimer/num_slowest_by_page',
+            get_string('num_slowest_by_page', 'tool_excimer'),
+            get_string('num_slowest_by_page_desc', 'tool_excimer'),
+            '5',
+            PARAM_INT
         );
+        $item->set_updatedcallback($clearprofiletimingscachecallback);
+        $settings->add($item);
+
     }
 
     $ADMIN->add(

--- a/settings.php
+++ b/settings.php
@@ -23,8 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use tool_excimer\manager;
-
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021122900;
-$plugin->release = 2021122900;
+$plugin->version = 2021123000;
+$plugin->release = 2021123000;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
- Caches the min duration per page and per reason (or profile type)
- Uses this cache to adjust the min duration required for it to be
  stored automatically when profiling, currently REASON_SLOW (or AUTO)
  is supported, but built it so other reasons can be supported as well.
- Add cache definition to tool_excimer
- Cache busting callback added on profile save, on certain setting
  updates, and when removing reasons via the purge task.
- Optimised some of the checks added, adding examples to the function
  docs.

Closes #121 Closes #106