### PR TITLE
Adds unit tests to ensure DB reads/writes stay as low as expected (#123) 

### DIFF
--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -505,13 +505,12 @@ class tool_excimer_profile_testcase extends advanced_testcase {
         $endreads = $DB->perf_get_reads();
         $endwrites = $DB->perf_get_writes();
 
-        // TODO: This does not apply pre PR#122 patch, since it currently just
-        // reads trigger_ms and will insert records (which isn't counted here)
-        // unnecessarily instead of leveraging the cache to avoid doing so.
-        // $totalreads = $endreads - $startreads;
-        // $totalwrites = $endwrites - $startwrites;
-        // $this->assertNotEmpty($totalreads);
-        // $this->assertNotEmpty($totalwrites); // Relevant once PR#122 merges.
+        // Tests that some activity has happened before the caches were warm,
+        // which means caching and the like is happening as expected.
+        $totalreads = $endreads - $startreads;
+        $totalwrites = $endwrites - $startwrites;
+        $this->assertNotEmpty($totalreads);
+        $this->assertNotEmpty($totalwrites);
 
         $totalwarmcachereads = $endreads - $startwarmcachereads;
         $totalwarmcachewrites = $endwrites - $startwarmcachewrites;

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -504,13 +504,17 @@ class tool_excimer_profile_testcase extends advanced_testcase {
 
         $endreads = $DB->perf_get_reads();
         $endwrites = $DB->perf_get_writes();
-        $totalreads = $endreads - $startreads;
-        $totalwrites = $endwrites - $startwrites;
+
+        // TODO: This does not apply pre PR#122 patch, since it currently just
+        // reads trigger_ms and will insert records (which isn't counted here)
+        // unnecessarily instead of leveraging the cache to avoid doing so.
+        // $totalreads = $endreads - $startreads;
+        // $totalwrites = $endwrites - $startwrites;
+        // $this->assertNotEmpty($totalreads);
+        // $this->assertNotEmpty($totalwrites); // Relevant once PR#122 merges.
+
         $totalwarmcachereads = $endreads - $startwarmcachereads;
         $totalwarmcachewrites = $endwrites - $startwarmcachewrites;
-
-        $this->assertNotEmpty($totalreads);
-        $this->assertNotEmpty($totalwrites);
         $this->assertEquals(0, $totalwarmcachereads);
         $this->assertEquals(0, $totalwarmcachewrites);
     }


### PR DESCRIPTION
Here is the output of a unit test with some echo'ing

_Note: true just indicates the is_considered_slow() method returned true and every other guard was passed_

```
Moodle 3.9.11+ (Build: 20211207), 65a1d355e3833d5eb031c604efcbf713748192e6
Php: 7.4.26, pgsql: 9.6.21, OS: Linux 5.4.0-91-generic x86_64
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, true : 3 R/W: 4/2
Duration: 3, true : 3 R/W: 5/2
Duration: 4, true : 4 R/W: 5/2
Duration: 5, true : 5 R/W: 5/2
Duration: 1, [triggerms false : 1] (min is 2) R/W: 1/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 2/1
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 2/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Duration: 1, [triggerms false : 1] (min is 2) R/W: 0/0
Duration: 2, [triggerms false : 2] (min is 2) R/W: 0/0
Duration: 3, [minduration false : 3] (min is 3) R/W: 0/0
Duration: 4, [requestminduration false : 4] (min is 4) R/W: 0/0
Array
(
    [reads] => 24
    [writes] => 9
    [warmcachereads] => 0
    [warmcachewrites] => 0
)
```

Closes #123 