### PR TITLE
Add readonly replica read count to db read / write stats #130 

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -216,6 +216,10 @@ class profile {
         // Get DB ops (reads/writes).
         $dbreads = $DB->perf_get_reads();
         $dbwrites = $DB->perf_get_writes();
+        $dbreplicareads = 0;
+        if ($DB->want_read_slave()) {
+            $dbreplicareads = $DB->perf_get_reads_slave();
+        }
 
         $intrans = $DB->is_transaction_started();
 
@@ -271,6 +275,7 @@ class profile {
                 'contenttypecategory' => $contenttypecategory,
                 'dbreads' => $dbreads,
                 'dbwrites' => $dbwrites,
+                'dbreplicareads' => $dbreplicareads,
             ]);
         } else {
             $db2->update_record('tool_excimer_profiles', (object) [
@@ -284,6 +289,7 @@ class profile {
                 'flamedatad3' => $flamedatad3gzip,
                 'dbreads' => $dbreads,
                 'dbwrites' => $dbwrites,
+                'dbreplicareads' => $dbreplicareads,
             ]);
             $id = self::$partialsaveid;
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20211231" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20220104" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -34,6 +34,7 @@
         <FIELD NAME="contenttypevalue" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="Raw content type as returned from the content-type response header, if available"/>
         <FIELD NAME="dbreads" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="dbwrites" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="dbreplicareads" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -206,5 +206,20 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2021123100, 'tool', 'excimer');
     }
 
+    if ($oldversion < 2022010400) {
+
+        // Define field dbreads to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('dbreplicareads', XMLDB_TYPE_INTEGER, '11', null, null, null, null, 'dbwrites');
+
+        // Conditionally launch add field dbreads.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022010400, 'tool', 'excimer');
+    }
+
     return true;
 }

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -84,6 +84,7 @@ $string['field_cookies'] = 'Cookies enabled';
 $string['field_buffering'] = 'Buffering enabled';
 $string['field_numsamples'] = 'Number of samples';
 $string['field_dbreadwrites'] = 'DB reads/writes';
+$string['field_dbreplicareads'] = 'DB reads from replica';
 $string['field_datasize'] = 'Size of profile data';
 $string['field_maxcreated'] = 'Latest';
 $string['field_mincreated'] = 'Earliest';

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -151,7 +151,10 @@
                     <th>{{#str}} field_versionhash, tool_excimer {{/str}}</th>
                     <td><span title="{{versionhash}}">{{#shortentext}} 20,{{versionhash}} {{/shortentext}}</span></td>
                 </tr>
-
+                <tr>
+                    <th>{{#str}} field_dbreplicareads, tool_excimer {{/str}}</th>
+                    <td>{{dbreplicareads}}</td>
+                </tr>
 
             </table>
         </div>

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2021123100;
-$plugin->release = 2021123100;
+$plugin->version = 2022010400;
+$plugin->release = 2022010400;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
Field defaults to zero when inserting, and sets it's actual value if a readreplica setup is detected (same way the performance footer does it)

![image](https://user-images.githubusercontent.com/9924643/148003816-08335ff7-f16c-4c48-a1b1-a23b92fba699.png)

DB r/w related fields on an example profile record:
```
            id: 23
       dbreads: 13245
      dbwrites: 60
dbreplicareads: 2291
1 row in set (0.00 sec)
```

Closes #130 