### PR TITLE
Issue #139: Performance overview check.

### DIFF
--- a/classes/check/slowest.php
+++ b/classes/check/slowest.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/  <--change
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer\check;
+
+use tool_excimer\profile;
+use tool_excimer\helper;
+
+use core\check\check;
+use core\check\result;
+
+/**
+ * A performance check to find the slowest profile.
+ *
+ * @package    tool_excimer
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright  2022 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class slowest extends check {
+    /**
+     * Links to the profile list ordered by duration.
+     *
+     * @return \action_link|null
+     * @throws \coding_exception
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/tool/excimer/slowest.php');
+        return new \action_link($url, get_string('checkslowest:action', 'tool_excimer'));
+    }
+
+    /**
+     * Gets info about the slowest profile.
+     *
+     * @return result
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public function get_result() : result {
+        $profile = profile::get_slowest_profile();
+        if ($profile === false) {
+            $status = result::OK;
+            $summary = get_string('checkslowest:none', 'tool_excimer');
+            $details = '';
+        } else {
+            $profile->duration = format_time($profile->duration);
+            $status = result::INFO;
+            $summary = get_string('checkslowest:summary', 'tool_excimer', $profile);
+            $profile->request = helper::full_request($profile);
+            $details = get_string('checkslowest:details', 'tool_excimer', $profile);
+        }
+        return new result($status, $summary, $details);
+    }
+}

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -146,81 +146,21 @@ class helper {
         }
     }
 
-    /**
-     * Checks the current response headers and tries to resolve the content type
-     * e.g. to store as part of the profile.
-     *
-     * @param      string $request the request of the profile to be stored.
-     * @param      string $pathinfo the pathinfo of the profile to be stored.
-     * @return     array containing [value, key, category]
-     *                   Where:
-     *                   - value is the raw content type detected,
-     *                   - key is the resolved filetype key or if not found, the
-     *                     detected extension.
-     *                   - category the general group it should fall under.
-     * @author     Kevin Pham <kevinpham@catalyst-au.net>
-     * @copyright  Catalyst IT, 2021
-     */
-    public static function resolve_content_type(string $request, string $pathinfo) {
-        $contenttypevalue = null;
-        $contenttypekey = null;
-        $contenttypecategory = null;
 
-        // Get 'Content-Type' header to perform further checks.
-        $headers = headers_list();
-        if (!empty($headers)) {
-            foreach ($headers as $header) {
-                $index = strpos(strtolower($header), 'content-type');
-                if ($index === 0) {
-                    list($contenttypewhole) = explode(';', $header, 2);
-                    list(, $contenttypevalue) = explode(': ', $contenttypewhole, 2);
-                    break;
-
-                }
+    public static function full_request(object $profile): string {
+        $displayedrequest = $profile->request . $profile->pathinfo;
+        if (!empty($profile->parameters)) {
+            if ($profile->scripttype == profile::SCRIPTTYPE_CLI) {
+                // For CLI scripts, request should look like `command.php --flag=value` as an example.
+                $separator = ' ';
+                $profile->parameters = escapeshellcmd($profile->parameters);
+            } else {
+                // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
+                $separator = '?';
+                $profile->parameters = urldecode($profile->parameters);
             }
+            $displayedrequest .= $separator . $profile->parameters;
         }
-
-        // If there is no Content-Type header detected, then bail since we
-        // aren't sure - it could be coming from CLI and thus needs no response
-        // headers, but the content type could vary (text/image) and there is no
-        // other checks for it at the moment.
-        // TODO: Should this check and prefill CLI based requests?
-
-        // Compare the value of 'Content-Type' to known values, to determine the content type fields.
-        $allfiletypes = core_filetypes::get_types();
-        // NOTE: This will stop on the FIRST match based on this list. It
-        // will also use the 'key' if the 'string' is not available.
-        foreach ($allfiletypes as $key => $filetype) {
-            if ($filetype['type'] === $contenttypevalue) {
-                $contenttypekey = $key;
-                $contenttypecategory = $filetype['string'] ?? $key;
-                break;
-            }
-        }
-
-        // If it cannot be determined via the core_filetypes, determine it based
-        // on known groups e.g. font.php, javascript.php, handlers, etc.
-        if (empty($contenttypekey)) {
-            $requestbasename = basename($request);
-            if (
-                $contenttypevalue === 'application/javascript' // Common, but not in filetypes as this exactly.
-                || $requestbasename === 'javascript.php'
-            ) {
-                $contenttypekey = 'js';
-                $contenttypecategory = 'js';
-            } else if ($requestbasename === 'font.php') {
-                list(, $trailingpathinfo) = explode('.', $pathinfo, 2);
-                list($extension) = explode('?', $trailingpathinfo, 2);
-
-                // Use the extension of the request to determine the 'key' (more
-                // or less analogous to the expected file extension anyways).
-                $contenttypekey = $extension;
-                $contenttypecategory = 'font';
-            }
-        }
-
-        return [$contenttypevalue, $contenttypekey, $contenttypecategory];
+        return $displayedrequest;
     }
-
-
 }

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -204,6 +204,22 @@ class profile extends persistent {
     }
 
     /**
+     * Returns the slowest profile on record.
+     *
+     * @return false|mixed The slowest profile, or false if no profiles are stored.
+     * @throws \dml_exception
+     */
+    public static function get_slowest_profile() {
+        global $DB;
+        return $DB->get_record_sql(
+            "SELECT id, request, duration, pathinfo, parameters, scripttype
+                FROM {tool_excimer_profiles}
+            ORDER BY duration DESC
+               LIMIT 1"
+        );
+    }
+
+    /**
      * Delete profiles created earlier than a given time.
      *
      * @param int $cutoff Epoch seconds

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -207,19 +207,7 @@ class profile_table extends \table_sql {
      * @return string
      */
     public function col_request(object $record): string {
-        $displayedrequest = $record->request . $record->pathinfo;
-        if (!empty($record->parameters)) {
-            if ($record->scripttype == profile::SCRIPTTYPE_CLI) {
-                // For CLI scripts, request should look like `command.php --flag=value` as an example.
-                $separator = ' ';
-                $record->parameters = escapeshellcmd($record->parameters);
-            } else {
-                // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
-                $separator = '?';
-                $record->parameters = urldecode($record->parameters);
-            }
-            $displayedrequest .= $separator . $record->parameters;
-        }
+        $displayedrequest = helper::full_request($record);
 
         // Return plaintext for download table response format.
         if ($this->is_downloading()) {

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -19,6 +19,7 @@
  *
  * @package   tool_excimer
  * @author    Nigel Chapman <nigelchapman@catalyst-au.net>
+ * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2021, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -30,6 +31,13 @@ $string['report_slowest'] = 'Profile list - slowest';
 $string['report_slowest_grouped'] = 'Profile list - slowest, grouped by request';
 $string['report_recent'] = 'Profile list - recent';
 $string['report_unfinished'] = 'Profile list - unfinished';
+
+// Check API.
+$string['checkslowest'] = 'Excimer profiles';
+$string['checkslowest:none'] = 'No profiles recorded.';
+$string['checkslowest:action'] = 'Slowest profiles list';
+$string['checkslowest:summary'] = 'Slowest profile is "{$a->request}" at {$a->duration}';
+$string['checkslowest:details'] = 'The longest running Excimer profile recorded is for the script/task "{$a->request}" at {$a->duration}.';
 
 // Settings.
 $string['here'] = 'here';

--- a/lib.php
+++ b/lib.php
@@ -24,6 +24,7 @@
  */
 
 use tool_excimer\manager;
+use tool_excimer\check\slowest;
 
 /**
  * Hook to be run after initial site config.
@@ -33,10 +34,14 @@ use tool_excimer\manager;
  * request up to this point will not be captured by the profiler. This
  * eliminates the need for an auto_prepend_file/auto_append_file.
  */
-function tool_excimer_after_config() {
+function tool_excimer_after_config(): void {
     // TODO Temp ref: https://docs.moodle.org/dev/Login_callbacks#after_config
     // TODO Do we want to check if in upgrade/install etc.
     if (class_exists('ExcimerProfiler') && manager::is_profiling()) {
         manager::init();
     }
+}
+
+function tool_excimer_performance_checks(): array {
+    return [new slowest()];
 }

--- a/profile.php
+++ b/profile.php
@@ -96,19 +96,7 @@ $deleteallbutton->add_confirm_action(get_string('deleteprofiles_script_warning',
 $data = (array) $profile->to_record();
 $data['duration'] = format_time($data['duration']);
 
-$data['request'] = $profile->get('request') . $profile->get('pathinfo');
-if (!empty($profile->get('parameters'))) {
-    $parameters = $profile->get('parameters');
-    if ($profile->get('scripttype') == profile::SCRIPTTYPE_CLI) {
-        // For CLI scripts, request should look like `command.php --flag=value` as an example.
-        $separator = ' ';
-    } else {
-        // For GET requests, request should look like `myrequest.php?myparam=1` as an example.
-        $separator = '?';
-        $parameters = urldecode($parameters);
-    }
-    $data['request'] .= $separator . $parameters;
-}
+$data['request'] = helper::full_request($profile->to_record());
 
 // If GET request then it should be reproducable as a idempotent request (readonly).
 if ($profile->get('method') === 'GET') {

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022011400;
-$plugin->release = 2022011400;
+$plugin->version = 2022011900;
+$plugin->release = 2022011900;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
resolves issue #139 
Added class 'tool_excimer\check\slowest'.
Added 'full_request()' to helper.
Refactored code top use 'helper::full_request()'.
Removed 'resolve_content_type()' from helper as redundant. (should have been removed as part of #146).
Added 'get_slowest_profile()' to profile.
Added checks to performance overview.