### PR TITLE
Issue 161 wip

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -138,14 +138,14 @@ class manager {
 
         self::$profiler->profiler = new \ExcimerProfiler();
         if (self::is_cron()) {
-            self::$profiler->timer->setPeriod(self::$profiler->sampleperiod * 0.3);
             cron_manager::set_callbacks(self::$profiler);
         } else {
-            self::$profiler->timer->setPeriod($timerinterval);
             self::set_callbacks(self::$profiler);
         }
 
         self::$profiler->profiler->setPeriod(self::$profiler->sampleperiod);
+        self::$profiler->timer->setPeriod($timerinterval);
+
         self::$profiler->profiler->start();
         self::$profiler->timer->start();
     }

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -34,7 +34,7 @@ class manager {
     const ABS_MIN_PERIOD = 20; // The absolute minimum period that can be tolerated.
     const EXCIMER_LONG_PERIOD = 10; // Default period for partial saves.
 
-    static $profiler = null;
+    private static $profiler = null;
 
     /**
      * Checks if the given flag is set

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022012500;
-$plugin->release = 2022012500;
+$plugin->version = 2022021600;
+$plugin->release = 2022021600;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
Resolves #161

Introduce a small timer period to make the timer and profiler trigger separately for cron tasks.
Use a loop to examine log entries on each interval.

There may still be incidents of 'on_interval called with no profile'. This is not because of any flaw in the logic, but because the timers are volatile on starting. The first action does not line up with the sample period set. The actions become more stable after the first one.

This is not known to affect profiling of cron tasks.