### PR TITLE
Refactor: use PHPUnit stubs

### DIFF
--- a/tests/excimer_mockery.php
+++ b/tests/excimer_mockery.php
@@ -1,0 +1,154 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Intermediary class to provide stubs for Excimer classes.
+ *
+ * @package    tool_eximer
+ * @author     Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright  2022, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class excimer_mockery extends \advanced_testcase {
+
+    /**
+     * Creates a stub for the ExcimerLogEntry class for testing purposes.
+     *
+     * Each element of tracedef defines a function. Either
+     * - x;12 - defines a closure file 'x', line 12.
+     * - m::n - defines a class method m::n
+     * - n    - defines a function
+     *
+     * @param array $tracedef
+     * @return \ExcimerLogEntry|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function get_log_entry_stub(array $tracedef) {
+        $newtrace = [];
+        foreach (array_reverse($tracedef) as $fn) {
+            $node = [];
+            if (strpos($fn, ';') !== false) {
+                $fn = explode(';', $fn);
+                $node['file'] = $fn[0];
+                $node['closure_line'] = $fn[1];
+            } else {
+                $fn = explode('::', $fn);
+                if (isset($fn[1])) {
+                    $node['class'] = $fn[0];
+                    $node['function'] = $fn[1];
+                } else {
+                    $node['function'] = $fn[0];
+                }
+            }
+            $newtrace[] = $node;
+        }
+
+        $stub = $this->getMockBuilder(\ExcimerLogEntry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('getTrace')
+            ->willReturn($newtrace);
+
+        return $stub;
+    }
+
+    /**
+     * Creates a stub for the ExcimerLog class for testing purposes.
+     *
+     * @param array $tracedefs
+     * @return \ExcimerLog|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function get_log_stub(array $tracedefs) {
+
+        $logentries = [];
+        foreach ($tracedefs as $tracedef) {
+            $logentries[] = $this->get_log_entry_stub($tracedef);
+        }
+        $logentries = new \ArrayObject($logentries);
+        $iterator = $logentries->getIterator();
+
+        $stub = $this->getMockBuilder(\ExcimerLog::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('current')
+            ->willReturnCallback(function() use($iterator) {
+                return $iterator->current();
+            });
+
+        $stub->method('key')
+            ->willReturnCallback(function() use($iterator) {
+                return $iterator->key();
+            });
+
+        $stub->method('next')
+            ->willReturnCallback(function() use($iterator) {
+                return $iterator->next();
+            });
+
+        $stub->method('rewind')
+            ->willReturnCallback(function() use($iterator) {
+                return $iterator->rewind();
+            });
+
+        $stub->method('valid')
+            ->willReturnCallback(function() use($iterator) {
+                return $iterator->valid();
+            });
+
+        $stub->method('count')
+            ->willReturnCallback(function() use($logentries) {
+                return $logentries->count();
+            });
+
+        $stub->method('offsetExists')
+            ->willReturnCallback(function($offset) use($logentries) {
+                return $logentries->offsetExists($offset);
+            });
+
+        $stub->method('offsetGet')
+            ->willReturnCallback(function($offset) use($logentries) {
+                return $logentries->offsetGet($offset);
+            });
+
+        return $stub;
+    }
+
+
+    /**
+     * Creates a stub for the ExcimerProfiler class for testing purposes.
+     *
+     * @param array $tracedefs
+     * @return \ExcimerProfiler|mixed|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function get_profiler_stub(array $tracedefs) {
+        $stub = $this->getMockBuilder(\ExcimerProfiler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $stub->method('flush')
+            ->willReturn($this->get_log_stub($tracedefs));
+
+        $stub->method('getLog')
+            ->willReturn($this->get_log_stub($tracedefs));
+
+        return $stub;
+    }
+}

--- a/tests/excimer_testcase.php
+++ b/tests/excimer_testcase.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  * @copyright  2022, Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class excimer_mockery extends \advanced_testcase {
+class excimer_testcase extends \advanced_testcase {
 
     /**
      * Creates a stub for the ExcimerLogEntry class for testing purposes.
@@ -88,45 +88,24 @@ class excimer_mockery extends \advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $stub->method('current')
-            ->willReturnCallback(function() use($iterator) {
-                return $iterator->current();
+        // These methods proxy the function names to $iterator for stubbing.
+        foreach (get_class_methods("\Iterator") as $methodname) {
+            $stub->method($methodname)->willReturnCallback(function() use($iterator, $methodname) {
+                return $iterator->$methodname();
             });
-
-        $stub->method('key')
-            ->willReturnCallback(function() use($iterator) {
-                return $iterator->key();
-            });
-
-        $stub->method('next')
-            ->willReturnCallback(function() use($iterator) {
-                return $iterator->next();
-            });
-
-        $stub->method('rewind')
-            ->willReturnCallback(function() use($iterator) {
-                return $iterator->rewind();
-            });
-
-        $stub->method('valid')
-            ->willReturnCallback(function() use($iterator) {
-                return $iterator->valid();
-            });
+        }
 
         $stub->method('count')
             ->willReturnCallback(function() use($logentries) {
                 return $logentries->count();
             });
 
-        $stub->method('offsetExists')
-            ->willReturnCallback(function($offset) use($logentries) {
-                return $logentries->offsetExists($offset);
+        // Don't use reflection here because not all methods need to be overridden.
+        foreach (['offsetExists', 'offsetGet'] as $methodname) {
+            $stub->method($methodname)->willReturnCallback(function($offset) use($logentries, $methodname) {
+                return $logentries->$methodname($offset);
             });
-
-        $stub->method('offsetGet')
-            ->willReturnCallback(function($offset) use($logentries) {
-                return $logentries->offsetGet($offset);
-            });
+        }
 
         return $stub;
     }

--- a/tests/tool_excimer_flamed3_node_test.php
+++ b/tests/tool_excimer_flamed3_node_test.php
@@ -18,6 +18,10 @@ namespace tool_excimer;
 
 use tool_excimer\flamed3_node;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not be automatically included.
+
 /**
  * Tests the flamed3_node class.
  *
@@ -26,49 +30,7 @@ use tool_excimer\flamed3_node;
  * @copyright 2021, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-class tool_excimer_flamed3_node_test extends \advanced_testcase {
-
-    /**
-     * Creates a stub for the ExcimerLogEntry class for testing purposes.
-     *
-     * Each element of tracedef defines a function. Either
-     * - x;12 - defines a closure file 'x', line 12.
-     * - m::n - defines a class method m::n
-     * - n    - defines a function
-     *
-     * @param array $tracedef
-     * @return \ExcimerLogEntry|mixed|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function get_log_entry_stub(array $tracedef) {
-        $newtrace = [];
-        foreach (array_reverse($tracedef) as $fn) {
-            $node = [];
-            if (strpos($fn, ';') !== false) {
-                $fn = explode(';', $fn);
-                $node['file'] = $fn[0];
-                $node['closure_line'] = $fn[1];
-            } else {
-                $fn = explode('::', $fn);
-                if (isset($fn[1])) {
-                    $node['class'] = $fn[0];
-                    $node['function'] = $fn[1];
-                } else {
-                    $node['function'] = $fn[0];
-                }
-            }
-            $newtrace[] = $node;
-        }
-
-        $stub = $this->getMockBuilder(\ExcimerLogEntry::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $stub->method('getTrace')
-            ->willReturn($newtrace);
-
-        return $stub;
-    }
+class tool_excimer_flamed3_node_test extends excimer_mockery {
 
     /**
      * Set up before each test

--- a/tests/tool_excimer_flamed3_node_test.php
+++ b/tests/tool_excimer_flamed3_node_test.php
@@ -20,7 +20,7 @@ use tool_excimer\flamed3_node;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not be automatically included.
+require_once(__DIR__ . "/excimer_testcase.php"); // This is needed. File will not be automatically included.
 
 /**
  * Tests the flamed3_node class.
@@ -30,7 +30,7 @@ require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not b
  * @copyright 2021, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_flamed3_node_test extends excimer_mockery {
+class tool_excimer_flamed3_node_test extends excimer_testcase {
 
     /**
      * Set up before each test

--- a/tests/tool_excimer_mockery_test.php
+++ b/tests/tool_excimer_mockery_test.php
@@ -19,7 +19,7 @@ namespace tool_excimer;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not be automatically included.
+require_once(__DIR__ . "/excimer_testcase.php"); // This is needed. File will not be automatically included.
 
 /**
  * Tests the excimer_mockry class.
@@ -29,7 +29,7 @@ require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not b
  * @copyright  2022, Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_mockery_test extends excimer_mockery {
+class tool_excimer_mockery_test extends excimer_testcase {
 
     /**
      * Tests excimer_mockery::get_log_entry_stub()

--- a/tests/tool_excimer_mockery_test.php
+++ b/tests/tool_excimer_mockery_test.php
@@ -1,0 +1,156 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+namespace tool_excimer;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__."/excimer_mockery.php"); // This is needed. File will not be automatically included.
+
+/**
+ * Tests the excimer_mockry class.
+ *
+ * @package    tool_excimer
+ * @author     Jason den Dulk <jasondendulk@catalyst-au.net>
+ * @copyright  2022, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tool_excimer_mockery_test extends excimer_mockery {
+
+    /**
+     * Tests excimer_mockery::get_log_entry_stub()
+     */
+    public function test_log_entry(): void {
+        $stub = $this->get_log_entry_stub(['c::a', 'b', 'c']);
+
+        $fns = $this->get_traces_from_entry($stub);
+        $this->assertEquals(['c', 'b', 'c::a'], $fns);
+    }
+
+    /**
+     * Tests excimer_mockery::get_log_stub()
+     */
+    public function test_log(): void {
+        $log = $this->get_log_stub([
+            ['c::a', 'b', 'c'],
+            ['c::a', 'd', 'e'],
+            ['m', 'n', 'f'],
+            ['M::m', 'n', 'e'],
+            ['M::m', 'l;12'],
+        ]);
+        $expected = [
+            ['c', 'b', 'c::a'],
+            ['e', 'd', 'c::a'],
+            ['f', 'n', 'm'],
+            ['e', 'n', 'M::m'],
+            ['{closure:l(12)}', 'M::m'],
+        ];
+
+        $trace = $this->get_traces_from_entry($log[0]);
+        $this->assertEquals($expected[0], $trace);
+        $traces = $this->get_traces_from_log($log);
+        $this->assertEquals($expected, $traces);
+    }
+
+    /**
+     * Tests excimer_mockery::get_profiler_stub()
+     */
+    public function test_profiler(): void {
+        $profiler = $this->get_profiler_stub([
+            ['co::ab', 'b', 'c'],
+            ['c::a', 'd', 'e'],
+            ['m', 'n', 'e'],
+            ['M::m', 'n', 'e'],
+            ['M::x', 'l;12'],
+        ]);
+        $expected = [
+            ['c', 'b', 'co::ab'],
+            ['e', 'd', 'c::a'],
+            ['e', 'n', 'm'],
+            ['e', 'n', 'M::m'],
+            ['{closure:l(12)}', 'M::x'],
+        ];
+
+        $traces = $this->get_traces_from_profile($profiler);
+        $this->assertEquals($expected, $traces);
+    }
+
+    /**
+     * Gets a string from a trace node array.
+     *
+     * @param array $tracenode An assoc. array containing a trace node as returned by ExcimerLogEntry::getTrace().
+     * @return string
+     */
+    protected function extract_name_from_trace(array $tracenode): string {
+        if (isset($tracenode['file'])) {
+            $tracenode['file'] = $tracenode['file'];
+        }
+        if (isset($tracenode['closure_line'])) {
+            return '{closure:' . $tracenode['file'] . '(' . $tracenode['closure_line'] . ')}';
+        }
+        if (!isset($tracenode['function'])) {
+            return $tracenode['file'];
+        }
+        if (isset($tracenode['class'])) {
+            $clname = $tracenode['class'] . '::';
+        } else {
+            $clname = '';
+        }
+        return $clname . $tracenode['function'];
+    }
+
+    /**
+     * Extracts traces from a profiler.
+     *
+     * @param \ExcimerProfiler $profile
+     * @return array
+     */
+    protected function get_traces_from_profile(\ExcimerProfiler $profile) {
+        return $this->get_traces_from_log($profile->getLog());
+    }
+
+    /**
+     * Extracts traces from a log.
+     *
+     * @param \ExcimerLog $log
+     * @return array
+     */
+    protected function get_traces_from_log(\ExcimerLog $log) {
+        $ret = [];
+        foreach ($log as $entry) {
+            $ret[] = $this->get_traces_from_entry($entry);
+        }
+        return $ret;
+    }
+
+    /**
+     * Extracts traces from a log entry.
+     *
+     * @param \ExcimerLogEntry $entry
+     * @return array
+     */
+    protected function get_traces_from_entry(\ExcimerLogEntry $entry) {
+        $ret = [];
+        $trace = $entry->getTrace();
+        foreach ($trace as $fn) {
+            $ret[] = $this->extract_name_from_trace($fn);
+        }
+        return $ret;
+    }
+}
+
+

--- a/tests/tool_excimer_mockery_test.php
+++ b/tests/tool_excimer_mockery_test.php
@@ -42,7 +42,7 @@ class tool_excimer_mockery_test extends excimer_testcase {
     }
 
     /**
-     * Tests excimer_mockery::get_log_stub()
+     * Tests excimer_testcase::get_log_stub()
      */
     public function test_log(): void {
         $log = $this->get_log_stub([
@@ -67,7 +67,7 @@ class tool_excimer_mockery_test extends excimer_testcase {
     }
 
     /**
-     * Tests excimer_mockery::get_profiler_stub()
+     * Tests excimer_testcase::get_profiler_stub()
      */
     public function test_profiler(): void {
         $profiler = $this->get_profiler_stub([
@@ -152,5 +152,3 @@ class tool_excimer_mockery_test extends excimer_testcase {
         return $ret;
     }
 }
-
-


### PR DESCRIPTION
Changed tool_excimer_flamed3_node_test to use a PHPUnit stub rather that a
custom mock class.