### PR TITLE
Issue #181: Swap durations back to use Moodle default.

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -92,21 +92,25 @@ class helper {
      * @throws \Exception
      */
     public static function duration_display(float $duration, bool $markup = true): string {
-        // Variable $markup allows a different format when downloaded vs viewed. It is currently unused.
-        if (intval($duration) > 10) {
-            // Use whole seconds.
-            $usetime = intval($duration);
-        } else {
-            // Add one decimal place.
-            $usetime = round($duration, 1);
-            // Fallback case to prevent format_time() returning the translated string 'now' when $usetime is less than 100ms.
-            // It will still appear if less than 1ms rounded. Discuss.
-            if ($usetime < 0.1) {
-                $usetime = round($duration, 3);
+        // Variable $markup allows a different format when viewed (true) vs downloaded (false).
+        if ($markup) {
+            if (intval($duration) > 10) {
+                // Use whole seconds.
+                $usetime = intval($duration);
+            } else {
+                // Add one decimal place.
+                $usetime = round($duration, 1);
+                // Fallback case to prevent format_time() returning the translated string 'now' when $usetime is less than 100ms.
+                // It will still appear if less than 1ms rounded. Discuss.
+                if ($usetime < 0.1) {
+                    $usetime = round($duration, 3);
+                }
             }
+            // This currently works with floats, but relies on undocumented behaviour of format_time(), which normally takes an int.
+            return format_time($usetime);
         }
-        // This currently works with floats, but relies on undocumented behaviour of format_time(), which normally takes an int.
-        return format_time($usetime);
+        // When downloading just provide the float.
+        return $duration;
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -92,15 +92,8 @@ class helper {
      * @throws \Exception
      */
     public static function duration_display(float $duration, bool $markup = true): string {
-        $ms = round($duration * 1000, 0) % 1000;
-        $s = (int) $duration;
-        $m = $s / 60;
-        $s = $s % 60;
-        if ($markup) {
-            return sprintf('%d:%02d<small>.%03d</small>', $m, $s, $ms);
-        } else {
-            return sprintf('%d:%02d.%03d', $m, $s, $ms);
-        }
+        $str = format_time(intval($duration));
+        return ($str === get_string('now') ? '' : $str);
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -92,8 +92,21 @@ class helper {
      * @throws \Exception
      */
     public static function duration_display(float $duration, bool $markup = true): string {
-        $str = format_time(intval($duration));
-        return ($str === get_string('now') ? '' : $str);
+        // Variable $markup allows a different format when downloaded vs viewed. It is currently unused.
+        if (intval($duration) > 10) {
+            // Use whole seconds.
+            $usetime = intval($duration);
+        } else {
+            // Add one decimal place.
+            $usetime = round($duration, 1);
+            // Fallback case to prevent format_time() returning the translated string 'now' when $usetime is less than 100ms.
+            // It will still appear if less than 1ms rounded. Discuss.
+            if ($usetime < 0.1) {
+                $usetime = round($duration, 3);
+            }
+        }
+        // This currently works with floats, but relies on undocumented behaviour of format_time(), which normally takes an int.
+        return format_time($usetime);
     }
 
     /**


### PR DESCRIPTION
  - this currently discards milliseconds and returns an empty string for anything under a second.
  - Please do not merge without additional peer review.