### PR TITLE
Add memory usage to the saved profiles

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -98,7 +98,7 @@ class cron_processor implements processor {
             }
 
             if ($taskname && ($this->currenttask == null)) {
-                $this->currenttask = new sample_set($taskname, $this->sampletime, script_metadata::get_sample_limit());
+                $this->currenttask = new sample_set($taskname, $this->sampletime);
             }
 
             if ($this->currenttask) {

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -158,6 +158,9 @@ class profile extends persistent {
     public function save_record(): int {
         global $DB, $USER;
 
+        // Get max memory usage.
+        $this->raw_set('memoryusagemax', memory_get_peak_usage());
+
         // Get DB ops (reads/writes).
         $this->raw_set('dbreads', $DB->perf_get_reads());
         $this->raw_set('dbwrites', $DB->perf_get_writes());
@@ -261,6 +264,7 @@ class profile extends persistent {
             'datasize' => ['type' => PARAM_INT, 'default' => 0],
             'numsamples' => ['type' => PARAM_INT, 'default' => 0],
             'memoryusagedatad3' => ['type' => PARAM_RAW],
+            'memoryusagemax' => ['type' => PARAM_INT],
             'flamedatad3' => ['type' => PARAM_RAW],
             'contenttypecategory' => ['type' => PARAM_TEXT, 'default' => ''],
             'contenttypekey' => ['type' => PARAM_TEXT],

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -164,7 +164,10 @@ class profile extends persistent {
         // Get DB ops (reads/writes).
         $this->raw_set('dbreads', $DB->perf_get_reads());
         $this->raw_set('dbwrites', $DB->perf_get_writes());
-        $this->raw_set('dbreplicareads', (method_exists($DB, 'want_read_slave') && $DB->want_read_slave()) ? $DB->perf_get_reads_slave() : 0);
+        $this->raw_set(
+            'dbreplicareads',
+            (method_exists($DB, 'want_read_slave') && $DB->want_read_slave()) ? $DB->perf_get_reads_slave() : 0
+        );
 
         $this->raw_set('responsecode', http_response_code());
 

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -90,6 +90,35 @@ class profile extends persistent {
         return gzuncompress($this->raw_get('flamedatad3'));
     }
 
+    /**
+     * Custom setter to set the memory usage d3 data.
+     *
+     * @param array $node
+     * @throws \coding_exception
+     */
+    protected function set_memoryusagedatad3(array $node): void {
+        $memoryusagejson = json_encode($node);
+        $this->raw_set('memoryusagedatad3', gzcompress($memoryusagejson));
+    }
+
+    protected function get_memoryusagedatad3(): string {
+        return json_decode($this->get_uncompressed_json('memoryusagedatad3'));
+    }
+
+    /**
+     * Special getter to obtain the uncompressed stored JSON.
+     *
+     * @return string
+     * @throws \coding_exception
+     */
+    public function get_uncompressed_json($fieldname): string {
+        $rawdata = $this->raw_get($fieldname);
+        if (isset($rawdata)) {
+            return gzuncompress($rawdata);
+        }
+        return json_encode(null);
+    }
+
     public function add_env(string $request): void {
         global $USER, $CFG;
 
@@ -231,6 +260,7 @@ class profile extends persistent {
             'versionhash' => ['type' => PARAM_TEXT, 'default' => ''],
             'datasize' => ['type' => PARAM_INT, 'default' => 0],
             'numsamples' => ['type' => PARAM_INT, 'default' => 0],
+            'memoryusagedatad3' => ['type' => PARAM_RAW],
             'flamedatad3' => ['type' => PARAM_RAW],
             'contenttypecategory' => ['type' => PARAM_TEXT, 'default' => ''],
             'contenttypekey' => ['type' => PARAM_TEXT],

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -44,12 +44,12 @@ class sample_set {
      *
      * @param string $name
      * @param float $starttime
-     * @param int $samplelimit
+     * @param ?int $samplelimit
      */
-    public function __construct(string $name, float $starttime, int $samplelimit) {
+    public function __construct(string $name, float $starttime, ?int $samplelimit = null) {
         $this->name = $name;
         $this->starttime = $starttime;
-        $this->samplelimit = $samplelimit;
+        $this->samplelimit = is_null($samplelimit) ? script_metadata::get_sample_limit() : $samplelimit;
     }
 
     /**

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -28,9 +28,10 @@ class sample_set {
     public $name;
     public $starttime;
 
-    /** array An array of \ExcimerLogEntry objects. */
+    /** @var array $samples An array of \ExcimerLogEntry objects. */
     public $samples = [];
 
+    /** @var ?int $samplelimit */
     public $samplelimit;
 
     /** @var int If $filterrate is R, then only each Rth sample is recorded. */
@@ -38,6 +39,9 @@ class sample_set {
 
     /** @var int Internal counter to help with filtering. */
     private $counter = 0;
+
+    /** @var int Internal counter of how many samples were added (regardless of how many are currently held). */
+    private $total_added = 0;
 
     /**
      * Constructs the sample set.
@@ -55,9 +59,9 @@ class sample_set {
     /**
      * Add a sample to the sample store, applying any filters.
      *
-     * @param array $sample
+     * @param array|\ExcimerLogEntry $sample
      */
-    public function add_sample(\ExcimerLogEntry $sample) {
+    public function add_sample($sample) {
         if (count($this->samples) === $this->samplelimit) {
             $this->apply_doubling();
         }
@@ -66,6 +70,7 @@ class sample_set {
             $this->samples[] = $sample;
             $this->counter = 0;
         }
+        $this->total_added++;
     }
 
     /**
@@ -98,5 +103,13 @@ class sample_set {
                 ARRAY_FILTER_USE_KEY
             )
         );
+    }
+
+    public function total_added() {
+        return $this->total_added;
+    }
+
+    public function count() {
+        return count($this->samples);
     }
 }

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -41,7 +41,7 @@ class sample_set {
     private $counter = 0;
 
     /** @var int Internal counter of how many samples were added (regardless of how many are currently held). */
-    private $total_added = 0;
+    private $totaladded = 0;
 
     /**
      * Constructs the sample set.
@@ -70,7 +70,7 @@ class sample_set {
             $this->samples[] = $sample;
             $this->counter = 0;
         }
-        $this->total_added++;
+        $this->totaladded++;
     }
 
     /**
@@ -105,10 +105,20 @@ class sample_set {
         );
     }
 
+    /**
+     * Number of samples that have gone through the add_sample method
+     *
+     * @return    int number of samples added
+     */
     public function total_added() {
-        return $this->total_added;
+        return $this->totaladded;
     }
 
+    /**
+     * Number of samples currently in possession
+     *
+     * @return    int count of $this->samples
+     */
     public function count() {
         return count($this->samples);
     }

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -41,7 +41,6 @@ class web_processor implements processor {
      * @param manager $manager The profiler manager object
      */
     public function init(manager $manager) {
-
         // Record and set initial memory usage at this point.
         $memoryusage = memory_get_usage();
 

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -35,9 +35,6 @@ class web_processor implements processor {
     protected $sampleset;
     protected $memoryusagesampleset;
 
-    /** @var int $memoryusagesampleindex */
-    protected $memoryusagesampleindex;
-
     /**
      * Initialises the processor
      *
@@ -51,14 +48,10 @@ class web_processor implements processor {
         $request = script_metadata::get_request();
         $starttime = (int) $manager->get_starttime();
         $this->sampleset = new sample_set($request, $starttime);
+
+        // Add sampleset for memory usage - this sets the baseline for the profile.
         $this->memoryusagesampleset = new sample_set($request, $starttime);
-
-
-        $this->memoryusagesampleset->add_sample([
-            // Value of the data.
-            'sampleindex' => 0,
-            'value' => $memoryusage,
-        ]);
+        $this->memoryusagesampleset->add_sample(['sampleindex' => 0, 'value' => $memoryusage]);
 
         $this->profile = new profile();
         $this->profile->add_env($this->sampleset->name);
@@ -97,9 +90,7 @@ class web_processor implements processor {
         $log = $manager->get_profiler()->flush();
         $this->sampleset->add_many_samples($log);
 
-        // Note: the label can probably be determined via the JS lib).
         $this->memoryusagesampleset->add_sample([
-            // Value of the data.
             'sampleindex' => $this->sampleset->total_added() + $this->memoryusagesampleset->count() - 1,
             'value' => memory_get_usage()
         ]);

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -42,8 +42,8 @@ class web_processor implements processor {
     public function init(manager $manager) {
         $this->sampleset = new sample_set(
             script_metadata::get_request(),
-            (int) $manager->get_starttime(),
-            script_metadata::get_sample_limit()
+            (int) $manager->get_starttime()
+        );
         );
 
         $this->profile = new profile();

--- a/db/install.xml
+++ b/db/install.xml
@@ -30,6 +30,7 @@
         <FIELD NAME="datasize" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Size of the profile data (in bytes)"/>
         <FIELD NAME="numsamples" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Number of samples taken"/>
         <FIELD NAME="flamedatad3" TYPE="binary" NOTNULL="false" SEQUENCE="false" COMMENT="Compressed JSON structure compatible with d3-flame-graph."/>
+        <FIELD NAME="memoryusagedatad3" TYPE="binary" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="contenttypecategory" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="core_filetypes' resolved string value"/>
         <FIELD NAME="contenttypekey" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="core_filetypes's key from the types available."/>
         <FIELD NAME="contenttypevalue" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="Raw content type as returned from the content-type response header, if available"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20220408" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20220411" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -40,6 +40,7 @@
         <FIELD NAME="usermodified" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The user who created/modified the object"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The timestamp at which the record was created"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The timestamp at which the record was modified"/>
+        <FIELD NAME="memoryusagemax" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="Maximum memory usage recorded for this given run. Note that CLI profiles might store the max for previous connected runs within the same process."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -272,7 +272,7 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022011400, 'tool', 'excimer');
     }
 
-    if ($oldversion < 2022040802) {
+    if ($oldversion < 2022041300) {
 
         // Change field 'parameters' into a text field.
         $table = new xmldb_table('tool_excimer_profiles');
@@ -282,8 +282,16 @@ function xmldb_tool_excimer_upgrade($oldversion) {
             $dbman->change_field_type($table, $field);
         }
 
+        // Define field memoryusagedatad3 to be added to tool_excimer_profiles.
+        $field = new xmldb_field('memoryusagedatad3', XMLDB_TYPE_BINARY, null, null, null, null, null, 'flamedatad3');
+
+        // Conditionally launch add field memoryusagedatad3.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
         // Excimer savepoint reached.
-        upgrade_plugin_savepoint(true, 2022040802, 'tool', 'excimer');
+        upgrade_plugin_savepoint(true, 2022041300, 'tool', 'excimer');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -294,5 +294,20 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022041300, 'tool', 'excimer');
     }
 
+    if ($oldversion < 2022022502) {
+
+        // Define field memoryusagemax to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('memoryusagemax', XMLDB_TYPE_INTEGER, '11', null, null, null, null, 'timemodified');
+
+        // Conditionally launch add field memoryusagemax.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022022502, 'tool', 'excimer');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -272,7 +272,7 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022011400, 'tool', 'excimer');
     }
 
-    if ($oldversion < 2022041300) {
+    if ($oldversion < 2022040802) {
 
         // Change field 'parameters' into a text field.
         $table = new xmldb_table('tool_excimer_profiles');
@@ -282,19 +282,20 @@ function xmldb_tool_excimer_upgrade($oldversion) {
             $dbman->change_field_type($table, $field);
         }
 
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022040802, 'tool', 'excimer');
+    }
+
+    if ($oldversion < 2022041300) {
+
         // Define field memoryusagedatad3 to be added to tool_excimer_profiles.
+        $table = new xmldb_table('tool_excimer_profiles');
         $field = new xmldb_field('memoryusagedatad3', XMLDB_TYPE_BINARY, null, null, null, null, null, 'flamedatad3');
 
         // Conditionally launch add field memoryusagedatad3.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
-
-        // Excimer savepoint reached.
-        upgrade_plugin_savepoint(true, 2022041300, 'tool', 'excimer');
-    }
-
-    if ($oldversion < 2022022502) {
 
         // Define field memoryusagemax to be added to tool_excimer_profiles.
         $table = new xmldb_table('tool_excimer_profiles');
@@ -306,8 +307,7 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         }
 
         // Excimer savepoint reached.
-        upgrade_plugin_savepoint(true, 2022022502, 'tool', 'excimer');
+        upgrade_plugin_savepoint(true, 2022041300, 'tool', 'excimer');
     }
-
     return true;
 }

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -109,6 +109,7 @@ $string['field_numsamples'] = 'Number of samples';
 $string['field_dbreadwrites'] = 'DB reads/writes';
 $string['field_dbreplicareads'] = 'DB reads from replica';
 $string['field_datasize'] = 'Size of profile data';
+$string['field_memoryusagemax'] = 'Max Memory Used';
 $string['field_maxcreated'] = 'Latest';
 $string['field_mincreated'] = 'Earliest';
 $string['field_maxduration'] = 'Slowest';

--- a/memoryusagegraph.json.php
+++ b/memoryusagegraph.json.php
@@ -1,0 +1,128 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * D3.js flamegraph data in JSON format.
+ *
+ * @package   tool_excimer
+ * @author    Nigel Chapman <nigelchapman@catalyst-au.net>
+ * @copyright 2021, Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_excimer\profile;
+
+require_once(__DIR__ . '/../../../config.php');
+
+require_once($CFG->libdir.'/adminlib.php');
+require_admin();
+
+$profileid = required_param('profileid', PARAM_INT);
+
+$profile = new profile($profileid);
+
+header('Content-Type: application/json; charset: utf-8');
+
+$jsondata = $profile->get_uncompressed_json('memoryusagedatad3');
+if (!empty($jsondata)) {
+    echo $jsondata;
+    die;
+}
+// Debugging - dummy data
+echo json_encode([
+['value' => 1],
+['value' => 2],
+['value' => 3],
+['value' => 4],
+['value' => 5],
+['value' => 6],
+['value' => 7],
+['value' => 8],
+['value' => 9],
+['value' => 10],
+['value' => 11],
+['value' => 12],
+['value' => 13],
+['value' => 14],
+['value' => 15],
+['value' => 16],
+['value' => 17],
+['value' => 18],
+['value' => 19],
+['value' => 20],
+['value' => 21],
+['value' => 22],
+['value' => 23],
+['value' => 24],
+['value' => 25],
+['value' => 26],
+['value' => 27],
+['value' => 28],
+['value' => 29],
+['value' => 30],
+['value' => 31],
+['value' => 32],
+['value' => 33],
+['value' => 34],
+['value' => 35],
+['value' => 36],
+['value' => 37],
+['value' => 38],
+['value' => 39],
+['value' => 40],
+['value' => 41],
+['value' => 42],
+['value' => 43],
+['value' => 44],
+['value' => 45],
+['value' => 46],
+['value' => 47],
+['value' => 48],
+['value' => 49],
+['value' => 50],
+['value' => 51],
+['value' => 52],
+['value' => 53],
+['value' => 54],
+['value' => 55],
+['value' => 56],
+['value' => 57],
+['value' => 58],
+['value' => 59],
+['value' => 60],
+['value' => 61],
+['value' => 62],
+['value' => 63],
+['value' => 64],
+['value' => 65],
+['value' => 66],
+['value' => 67],
+['value' => 68],
+['value' => 69],
+['value' => 70],
+['value' => 71],
+['value' => 72],
+['value' => 73],
+['value' => 74],
+['value' => 75],
+['value' => 76],
+['value' => 77],
+['value' => 78],
+['value' => 79],
+['value' => 80],
+]);
+die;
+

--- a/memoryusagegraph.json.php
+++ b/memoryusagegraph.json.php
@@ -18,8 +18,8 @@
  * D3.js flamegraph data in JSON format.
  *
  * @package   tool_excimer
- * @author    Nigel Chapman <nigelchapman@catalyst-au.net>
- * @copyright 2021, Catalyst IT
+ * @author    Kevin Pham <kevinpham@catalyst-au.net>
+ * @copyright Catalyst IT, 2022
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -39,90 +39,4 @@ header('Content-Type: application/json; charset: utf-8');
 $jsondata = $profile->get_uncompressed_json('memoryusagedatad3');
 if (!empty($jsondata)) {
     echo $jsondata;
-    die;
 }
-// Debugging - dummy data
-echo json_encode([
-['value' => 1],
-['value' => 2],
-['value' => 3],
-['value' => 4],
-['value' => 5],
-['value' => 6],
-['value' => 7],
-['value' => 8],
-['value' => 9],
-['value' => 10],
-['value' => 11],
-['value' => 12],
-['value' => 13],
-['value' => 14],
-['value' => 15],
-['value' => 16],
-['value' => 17],
-['value' => 18],
-['value' => 19],
-['value' => 20],
-['value' => 21],
-['value' => 22],
-['value' => 23],
-['value' => 24],
-['value' => 25],
-['value' => 26],
-['value' => 27],
-['value' => 28],
-['value' => 29],
-['value' => 30],
-['value' => 31],
-['value' => 32],
-['value' => 33],
-['value' => 34],
-['value' => 35],
-['value' => 36],
-['value' => 37],
-['value' => 38],
-['value' => 39],
-['value' => 40],
-['value' => 41],
-['value' => 42],
-['value' => 43],
-['value' => 44],
-['value' => 45],
-['value' => 46],
-['value' => 47],
-['value' => 48],
-['value' => 49],
-['value' => 50],
-['value' => 51],
-['value' => 52],
-['value' => 53],
-['value' => 54],
-['value' => 55],
-['value' => 56],
-['value' => 57],
-['value' => 58],
-['value' => 59],
-['value' => 60],
-['value' => 61],
-['value' => 62],
-['value' => 63],
-['value' => 64],
-['value' => 65],
-['value' => 66],
-['value' => 67],
-['value' => 68],
-['value' => 69],
-['value' => 70],
-['value' => 71],
-['value' => 72],
-['value' => 73],
-['value' => 74],
-['value' => 75],
-['value' => 76],
-['value' => 77],
-['value' => 78],
-['value' => 79],
-['value' => 80],
-]);
-die;
-

--- a/profile.php
+++ b/profile.php
@@ -137,5 +137,7 @@ $tabs = new tabs($url);
 $data['tabs'] = $tabs->export_for_template($output)['tabs'];
 
 echo $output->header();
+echo $output->render_from_template('tool_excimer/profile', $data);
 echo $output->render_from_template('tool_excimer/flamegraph', $data);
+echo $output->render_from_template('tool_excimer/memoryusagegraph', $data);
 echo $output->footer();

--- a/profile.php
+++ b/profile.php
@@ -120,6 +120,7 @@ $data['reason_display'] = function($text, $render) {
 };
 
 $data['datasize'] = display_size($profile->get('datasize'));
+$data['memoryusagemax'] = display_size($profile->get('memoryusagemax'));
 $data['delete_button'] = $output->render($deletebutton);
 $data['delete_all_button'] = $output->render($deleteallbutton);
 

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -15,7 +15,7 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template tool_excimer/profile_page
+    @template tool_excimer/flamegraph
 
     Markup for displaying a flame graph.
 
@@ -27,33 +27,10 @@
 
     Context variables required for this template:
     * id - The id of the profile
-    * request - The request url (with pathinfo and parameters)
-    * sessionid - The session ID
-    * userid - ID of the user who loaded the page
-    * scripttype - The script type
-    * created - Unix timestamp of profile creation
-    * duration - Profile duration in seconds.
-    * resposnecode - HTTP response code
-    * cookies - Is cookies enabled?
-    * buffering - Is buffering enabled?
-    * fullname - Full nane of user represented by userid.
-    * userlink - Link to user's profile page, or null if no user.
-    * tabs - Tabs markup.
 
     Example context (json):
     {
         "id" : 3,
-        "request" : "/my/index.php/another/deeper/path?time=day&duration=week",
-        "sessionid" : "9842abcdef",
-        "scripttype" : 2,
-        "created" : 1638244603,
-        "duration" : 0.153,
-        "resposnecode" : 200,
-        "cookies" : 1,
-        "buffering" : 1,
-        "fullname" : "Admin User",
-        "userlink" : "https://some.domain://user/profile?id=1',
-        "tabs" : "<ul></ul>"
     }
 }}
 

--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -57,122 +57,14 @@
     }
 }}
 
-{{> core/tabtree}}
-<h3>{{{responsecode}}} {{method}} {{{request}}}</h3>
-<p>{{{delete_button}}} {{{delete_all_button}}}</p>
-
-<div id="profile-stats" class="container">
-    <div class="row">
-        <div class="">
-            <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
-                <tr>
-                    <th>{{#str}} field_contenttype, tool_excimer {{/str}}</th>
-                        <td>
-                        <span title="{{#str}} field_contenttypecategory, tool_excimer {{/str}}">{{contenttypecategory}}</span>
-                        -
-                        <span title="{{#str}} field_contenttypekey, tool_excimer {{/str}}">.{{contenttypekey}}</span>
-                        -
-                        <span title="{{#str}} field_contenttypevalue, tool_excimer {{/str}}">{{contenttypevalue}}</span>
-                    </td>
-                </tr>
-
-                <tr>
-                    <th>{{#str}} field_sessionid, tool_excimer {{/str}}</th>
-                    <td>{{sessionid}}...</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_reason, tool_excimer {{/str}}</th>
-                    <td>{{#reason_display}}{{reason}}{{/reason_display}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_scripttype, tool_excimer {{/str}}</th>
-                    <td>{{#script_type_display}}{{scripttype}}{{/script_type_display}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_created, tool_excimer {{/str}}</th>
-                    <td>{{#userdate}} {{created}}, {{#str}} strftimedaydatetime, langconfig {{/str}} {{/userdate}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_finished, tool_excimer {{/str}}</th>
-                    <td>
-                        {{#finished}}
-                            {{#userdate}} {{finished}}, {{#str}} strftimedaydatetime, langconfig {{/str}} {{/userdate}}
-                        {{/finished}}
-                        {{^finished}}
-                            {{#str}} didnotfinish, tool_excimer {{/str}}
-                        {{/finished}}
-                    </td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_duration, tool_excimer {{/str}}</th>
-                    <td>{{{duration}}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_numsamples, tool_excimer {{/str}}</th>
-                    <td>{{numsamples}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_dbreadwrites, tool_excimer {{/str}}</th>
-                    <td>{{dbreads}}/{{dbwrites}}</td>
-                </tr>
-            </table>
-        </div>
-        <div class="">
-            <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
-                <tr>
-                    <th>{{#str}} field_datasize, tool_excimer {{/str}}</th>
-                    <td>{{datasize}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_cookies, tool_excimer {{/str}}</th>
-                    <td>{{#cookies}} {{#str}} yes, core_customfield {{/str}} {{/cookies}}{{^cookies}}{{#str}} no, core_customfield {{/str}}{{/cookies}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_buffering, tool_excimer {{/str}}</th>
-                    <td>{{#buffering}} {{#str}} yes, core_customfield {{/str}} {{/buffering}}{{^buffering}}{{#str}} no, core_customfield {{/str}}{{/buffering}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_userid, tool_excimer {{/str}}</th>
-                    <td>{{#userlink}}<a href="{{userlink}}">{{fullname}}</a>{{/userlink}}
-                        {{^userlink}}{{fullname}}{{/userlink}}</td>
-                </tr>
-
-                <tr>
-                    <th>{{#str}} field_pid, tool_excimer {{/str}}</th>
-                    <td>{{pid}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_hostname, tool_excimer {{/str}}</th>
-                    <td>{{hostname}}</td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_useragent, tool_excimer {{/str}}</th>
-                    <td><span title="{{useragent}}">{{#shortentext}} 20,{{useragent}} {{/shortentext}}</span></td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_versionhash, tool_excimer {{/str}}</th>
-                    <td><span title="{{versionhash}}">{{#shortentext}} 20,{{versionhash}} {{/shortentext}}</span></td>
-                </tr>
-                <tr>
-                    <th>{{#str}} field_dbreplicareads, tool_excimer {{/str}}</th>
-                    <td>{{dbreplicareads}}</td>
-                </tr>
-
-            </table>
-        </div>
-    </div>
-</div>
-
 <h4>Profile Flame Graph</h4>
 
 <div id="loading">
     Loading...
 </div>
 
-<div id="chart" style="margin-top: 1rem;">
-</div>
-<div id="details" style="min-height: 1.5rem; clear: both;">
-</div>
+<div id="flamechart" style="margin-top: 1rem;"></div>
+<div id="flamedetails" style="min-height: 1.5rem; clear: both;"></div>
 
 <script type="text/javascript">
 
@@ -181,14 +73,14 @@ window.addEventListener('resize', _ => init());
 
 function init() {
 
-    let chart = document.getElementById('chart');
-    let details = document.getElementById("details");
+    let flamechart = document.getElementById('flamechart');
+    let flamedetails = document.getElementById("flamedetails");
 
-    const chartWidth = Math.max(chart.offsetWidth - 15, 500);
+    const chartWidth = Math.max(flamechart.offsetWidth - 15, 500);
 
     window.excimerChart = flamegraph();
     window.excimerChart.width(chartWidth);
-    window.excimerChart.setDetailsElement(details);
+    window.excimerChart.setDetailsElement(flamedetails);
 
     if (window.excimerData === undefined) {
         setLoading(true);
@@ -206,12 +98,12 @@ function init() {
 }
 
 function draw() {
-    let svg = document.querySelector('#chart svg');
+    let svg = document.querySelector('#flamechart svg');
     if (svg !== null) {
         svg.remove();
     }
-    //  Append SVG:
-    d3.select("#chart").datum(window.excimerData).call(window.excimerChart);
+    // Append SVG:
+    d3.select("#flamechart").datum(window.excimerData).call(window.excimerChart);
 }
 
 function setLoading(yn) {

--- a/templates/memoryusagegraph.mustache
+++ b/templates/memoryusagegraph.mustache
@@ -89,7 +89,35 @@ div.tooltip {
 </style>
 
 <script type="text/javascript">
+
+/**
+ * Generate the display for file size
+ * @param int size The size to convert to human readable form
+ * @return string
+ */
+const display_size = function(size) {
+    // This is snippet of code (with some changes) is from the display_size function in moodlelib.
+    var gb = "{{#str}} sizegb, moodle {{/str}}",
+        mb = "{{#str}} sizemb, moodle {{/str}}",
+        kb = "{{#str}} sizekb, moodle {{/str}}",
+        b  = "{{#str}} sizeb, moodle {{/str}}"
+
+    if (size >= 1073741824) {
+        size = Math.round(size / 1073741824 * 10) / 10 + gb;
+    } else if (size >= 1048576) {
+        size = Math.round(size / 1048576 * 10) / 10 + mb;
+    } else if (size >= 1024) {
+        size = Math.round(size / 1024 * 10) / 10 + kb;
+    } else {
+        size = parseInt(size, 10) + ' ' + b;
+    }
+
+    return size;
+}
+
 let excimerData;
+let memoryusagedetails = document.getElementById("memoryusagedetails");
+
 const memUsageInit = async () => {
 
     const setLoading = (yn) => {
@@ -118,7 +146,6 @@ memUsageInit();
 window.addEventListener('resize', memUsageInit);
 
 // Get the data
-// d3.csv('/admin/tool/excimer/memoryusagegraph.json.php?profileid={{id}}')
 function processGraph(id, data) {
     let existingSvg = document.querySelector(`#${id} svg`);
     if (existingSvg !== null) {
@@ -129,19 +156,18 @@ function processGraph(id, data) {
     let graph = document.getElementById(id);
     const chartWidth = Math.max(graph.offsetWidth - 15, 500);
     // NOTE: left=70 is used to display the numerical range, but it will not line up with the flame chart samples so is removed
-    var margin = {top: 0, right: 0, bottom: 30, left: 0},
-        // width = 960 - margin.left - margin.right,
+    var margin = {top: 10, right: 5, bottom: 30, left: 5},
         width = chartWidth,
         height = 200;
 
     // set the ranges
     // var x = d3.scaleTime().range([0, width]); // if dates
-    var x = d3.scaleBand().range([0, width]); // if ordinal scale (such as samples vs mem-usage)
+    var x = d3.scaleLinear().range([0, width]); // if ordinal scale (such as samples vs mem-usage)
     var y = d3.scaleLinear().range([height, 0]);
 
     // define the line
     var valueline = d3.line()
-        .x(function(d) { return x(d.close); })
+        .x(function(d) { return x(d.sampleindex); })
         .y(function(d) { return y(d.value); });
 
     // append the svg obgect to the body of the page
@@ -158,7 +184,6 @@ function processGraph(id, data) {
 
 
   // format the data
-  let counter = 1
   data.forEach(function(d) {
       d.sampleindex;
       d.value = +d.value;
@@ -170,44 +195,15 @@ function processGraph(id, data) {
       .style("opacity", 0);
 
   // Scale the range of the data
-  // x.domain(d3.extent(data, function(d) { return d.sampleindex; }));
-  x.domain(data.map(function(d) { return d.sampleindex; }));
+  x.domain([0, d3.max(data, function(d) { return d.sampleindex; })]);
   y.domain([0, d3.max(data, function(d) { return d.value; })]);
-
-  x.paddingInner(0)
-      .paddingOuter(0)
-      .align(0)
 
   // Add the valueline path.
   svg.append('path')
-      // .data([data])
+      .data([data])
       .datum(data)
       .attr('class', 'memory-usage-line')
       .attr('d', valueline);
-
-  // add the dots with tooltips
-  svg.selectAll("dot")
-     .data(data)
-   .enter().append("circle")
-     .attr("r", 5)
-     .attr("cx", function(d) { return x(d.sampleindex); })
-     .attr("cy", function(d) { return y(d.value); })
-     .on("mouseover", function(event, d) {
-       div.transition()
-         .duration(200)
-         .style("opacity", .9);
-       div.html(`
-           Sample #${d.sampleindex} <br/>
-           Bytes: ${d.value}
-       `)
-         .style("left", (event.pageX) + "px")
-         .style("top", (event.pageY - 28) + "px");
-       })
-     .on("mouseout", function(d) {
-       div.transition()
-         .duration(500)
-         .style("opacity", 0);
-       });
 
   // Add the x Axis
   svg.append('g')
@@ -218,34 +214,35 @@ function processGraph(id, data) {
   svg.append('g')
       .call(d3.axisLeft(y));
 
-  // // What happens when the mouse move -> show the annotations at the right positions.
-  // const mouseover = () => {
-  //   focus.style("opacity", 1)
-  //   focusText.style("opacity",1)
-  // }
-  //
-  // const mousemove = () => {
-  //   // recover coordinate we need
-  //   var x0 = x.invert(d3.pointer(this)[0]);
-  //   var i = bisect(data, x0, 1);
-  //   selectedData = data[i]
-  //   focus
-  //     .attr("cx", x(selectedData.x))
-  //     .attr("cy", y(selectedData.y))
-  //   focusText
-  //     .html("x:" + selectedData.x + "  -  " + "y:" + selectedData.y)
-  //     .attr("x", x(selectedData.x)+15)
-  //     .attr("y", y(selectedData.y))
-  // }
-  //
-  // const mouseout = () => {
-  //   focus.style("opacity", 0)
-  //   focusText.style("opacity", 0)
-  // }
-  //
-  // svg.on('mouseover', mouseover)
-  //   .on('mousemove', mousemove)
-  //   .on('mouseout', mouseout);
+  // add the dots with tooltips
+  svg.selectAll("dot")
+      .data(data)
+  .enter().append("circle")
+      .attr("r", 5)
+      .attr("cx", function(d) { return x(d.sampleindex); })
+      .attr("cy", function(d) { return y(d.value); })
+      .on("mouseover", function(event, d) {
+          div.transition()
+              .duration(200)
+              .style("opacity", .9);
+
+          div.html(`
+              Sample #${d.sampleindex} <br/>
+              Memory: ${display_size(d.value)}
+          `)
+              .style("left", (event.pageX) + "px")
+              .style("top", (event.pageY - 28) + "px");
+
+          memoryusagedetails.innerHTML = `
+              Sample #${d.sampleindex}, Memory Usage: ${display_size(d.value)}
+          `
+       })
+     .on("mouseout", function(d) {
+       div.transition()
+         .duration(100)
+         .style("opacity", 0);
+         memoryusagedetails.innerHTML = null
+       });
 
 }
 

--- a/templates/memoryusagegraph.mustache
+++ b/templates/memoryusagegraph.mustache
@@ -1,0 +1,252 @@
+{{!
+    This file is part of Moodle - https://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template tool_excimer/profile_page
+
+    Markup for displaying a flame graph.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * id - The id of the profile
+    * request - The request url (with pathinfo and parameters)
+    * sessionid - The session ID
+    * userid - ID of the user who loaded the page
+    * scripttype - The script type
+    * created - Unix timestamp of profile creation
+    * duration - Profile duration in seconds.
+    * resposnecode - HTTP response code
+    * cookies - Is cookies enabled?
+    * buffering - Is buffering enabled?
+    * fullname - Full nane of user represented by userid.
+    * userlink - Link to user's profile page, or null if no user.
+    * tabs - Tabs markup.
+
+    Example context (json):
+    {
+        "id" : 3,
+        "request" : "/my/index.php/another/deeper/path?time=day&duration=week",
+        "sessionid" : "9842abcdef",
+        "scripttype" : 2,
+        "created" : 1638244603,
+        "duration" : 0.153,
+        "resposnecode" : 200,
+        "cookies" : 1,
+        "buffering" : 1,
+        "fullname" : "Admin User",
+        "userlink" : "https://some.domain://user/profile?id=1',
+        "tabs" : "<ul></ul>"
+    }
+}}
+
+<h4>Memory Usage</h4>
+
+<div id="loadingmemoryusagegraph">
+    Loading...
+</div>
+
+<div id="memoryusagegraph" style="margin-top: 1rem;"></div>
+<div id="memoryusagedetails" style="min-height: 1.5rem; clear: both;"></div>
+
+
+<style>
+.memory-usage-line {
+  fill: none;
+  stroke: steelblue;
+  stroke-width: 2px;
+}
+div.tooltip {
+    position: absolute;
+    text-align: left;
+    width: 150px;
+    height: 40px;
+    padding: 5px 10px;
+    font: 12px sans-serif;
+    background: black;
+    color: white;
+    border: 0px;
+    border-radius: 8px;
+    pointer-events: none;
+}
+</style>
+
+<script type="text/javascript">
+let excimerData;
+const memUsageInit = async () => {
+
+    const setLoading = (yn) => {
+        document.getElementById('loadingmemoryusagegraph').style.display = yn ? 'block' : 'none';
+    }
+
+    let graph = document.getElementById('memoryusagegraph');
+    let details = document.getElementById('memoryusagedetails');
+    if (excimerData === undefined) {
+        setLoading(true);
+        try {
+            const data = await d3.json('/admin/tool/excimer/memoryusagegraph.json.php?profileid={{id}}')
+            setLoading(false);
+            excimerData = data;
+            processGraph('memoryusagegraph', excimerData);
+        } catch (error) {
+            console.warn(error);
+        }
+    } else {
+        processGraph('memoryusagegraph', excimerData);
+    }
+}
+
+// Main execution.
+memUsageInit();
+window.addEventListener('resize', memUsageInit);
+
+// Get the data
+// d3.csv('/admin/tool/excimer/memoryusagegraph.json.php?profileid={{id}}')
+function processGraph(id, data) {
+    let existingSvg = document.querySelector(`#${id} svg`);
+    if (existingSvg !== null) {
+        existingSvg.remove();
+    }
+
+    // Prep
+    let graph = document.getElementById(id);
+    const chartWidth = Math.max(graph.offsetWidth - 15, 500);
+    // NOTE: left=70 is used to display the numerical range, but it will not line up with the flame chart samples so is removed
+    var margin = {top: 0, right: 0, bottom: 30, left: 0},
+        // width = 960 - margin.left - margin.right,
+        width = chartWidth,
+        height = 200;
+
+    // set the ranges
+    // var x = d3.scaleTime().range([0, width]); // if dates
+    var x = d3.scaleBand().range([0, width]); // if ordinal scale (such as samples vs mem-usage)
+    var y = d3.scaleLinear().range([height, 0]);
+
+    // define the line
+    var valueline = d3.line()
+        .x(function(d) { return x(d.close); })
+        .y(function(d) { return y(d.value); });
+
+    // append the svg obgect to the body of the page
+    // appends a 'group' element to 'svg'
+    // moves the 'group' element to the top left margin
+    var svg = d3
+      .select(`#${id}`)
+      .append('svg')
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+        .attr('transform',
+              'translate(' + margin.left + ',' + margin.top + ')');
+
+
+  // format the data
+  let counter = 1
+  data.forEach(function(d) {
+      d.sampleindex;
+      d.value = +d.value;
+  });
+
+  // Tooltip DOM element
+  var div = d3.select("body").append("div")
+      .attr("class", "tooltip")
+      .style("opacity", 0);
+
+  // Scale the range of the data
+  // x.domain(d3.extent(data, function(d) { return d.sampleindex; }));
+  x.domain(data.map(function(d) { return d.sampleindex; }));
+  y.domain([0, d3.max(data, function(d) { return d.value; })]);
+
+  x.paddingInner(0)
+      .paddingOuter(0)
+      .align(0)
+
+  // Add the valueline path.
+  svg.append('path')
+      // .data([data])
+      .datum(data)
+      .attr('class', 'memory-usage-line')
+      .attr('d', valueline);
+
+  // add the dots with tooltips
+  svg.selectAll("dot")
+     .data(data)
+   .enter().append("circle")
+     .attr("r", 5)
+     .attr("cx", function(d) { return x(d.sampleindex); })
+     .attr("cy", function(d) { return y(d.value); })
+     .on("mouseover", function(event, d) {
+       div.transition()
+         .duration(200)
+         .style("opacity", .9);
+       div.html(`
+           Sample #${d.sampleindex} <br/>
+           Bytes: ${d.value}
+       `)
+         .style("left", (event.pageX) + "px")
+         .style("top", (event.pageY - 28) + "px");
+       })
+     .on("mouseout", function(d) {
+       div.transition()
+         .duration(500)
+         .style("opacity", 0);
+       });
+
+  // Add the x Axis
+  svg.append('g')
+      .attr('transform', 'translate(0,' + height + ')')
+      .call(d3.axisBottom(x));
+
+  // Add the y Axis
+  svg.append('g')
+      .call(d3.axisLeft(y));
+
+  // // What happens when the mouse move -> show the annotations at the right positions.
+  // const mouseover = () => {
+  //   focus.style("opacity", 1)
+  //   focusText.style("opacity",1)
+  // }
+  //
+  // const mousemove = () => {
+  //   // recover coordinate we need
+  //   var x0 = x.invert(d3.pointer(this)[0]);
+  //   var i = bisect(data, x0, 1);
+  //   selectedData = data[i]
+  //   focus
+  //     .attr("cx", x(selectedData.x))
+  //     .attr("cy", y(selectedData.y))
+  //   focusText
+  //     .html("x:" + selectedData.x + "  -  " + "y:" + selectedData.y)
+  //     .attr("x", x(selectedData.x)+15)
+  //     .attr("y", y(selectedData.y))
+  // }
+  //
+  // const mouseout = () => {
+  //   focus.style("opacity", 0)
+  //   focusText.style("opacity", 0)
+  // }
+  //
+  // svg.on('mouseover', mouseover)
+  //   .on('mousemove', mousemove)
+  //   .on('mouseout', mouseout);
+
+}
+
+</script>

--- a/templates/memoryusagegraph.mustache
+++ b/templates/memoryusagegraph.mustache
@@ -15,9 +15,9 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template tool_excimer/profile_page
+    @template tool_excimer/memoryusagegraph
 
-    Markup for displaying a flame graph.
+    Markup for displaying a line graph.
 
     Classes required for JS:
     * none
@@ -27,33 +27,10 @@
 
     Context variables required for this template:
     * id - The id of the profile
-    * request - The request url (with pathinfo and parameters)
-    * sessionid - The session ID
-    * userid - ID of the user who loaded the page
-    * scripttype - The script type
-    * created - Unix timestamp of profile creation
-    * duration - Profile duration in seconds.
-    * resposnecode - HTTP response code
-    * cookies - Is cookies enabled?
-    * buffering - Is buffering enabled?
-    * fullname - Full nane of user represented by userid.
-    * userlink - Link to user's profile page, or null if no user.
-    * tabs - Tabs markup.
 
     Example context (json):
     {
         "id" : 3,
-        "request" : "/my/index.php/another/deeper/path?time=day&duration=week",
-        "sessionid" : "9842abcdef",
-        "scripttype" : 2,
-        "created" : 1638244603,
-        "duration" : 0.153,
-        "resposnecode" : 200,
-        "cookies" : 1,
-        "buffering" : 1,
-        "fullname" : "Admin User",
-        "userlink" : "https://some.domain://user/profile?id=1',
-        "tabs" : "<ul></ul>"
     }
 }}
 

--- a/templates/profile.mustache
+++ b/templates/profile.mustache
@@ -15,9 +15,9 @@
     along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 }}
 {{!
-    @template tool_excimer/profile_page
+    @template tool_excimer/profile
 
-    Markup for displaying a flame graph.
+    Markup for displaying the summary of the excimer profile
 
     Classes required for JS:
     * none

--- a/templates/profile.mustache
+++ b/templates/profile.mustache
@@ -1,0 +1,164 @@
+{{!
+    This file is part of Moodle - https://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template tool_excimer/profile_page
+
+    Markup for displaying a flame graph.
+
+    Classes required for JS:
+    * none
+
+    Data attributes required for JS:
+    * none
+
+    Context variables required for this template:
+    * id - The id of the profile
+    * request - The request url (with pathinfo and parameters)
+    * sessionid - The session ID
+    * userid - ID of the user who loaded the page
+    * scripttype - The script type
+    * created - Unix timestamp of profile creation
+    * duration - Profile duration in seconds.
+    * resposnecode - HTTP response code
+    * cookies - Is cookies enabled?
+    * buffering - Is buffering enabled?
+    * fullname - Full nane of user represented by userid.
+    * userlink - Link to user's profile page, or null if no user.
+    * tabs - Tabs markup.
+
+    Example context (json):
+    {
+        "id" : 3,
+        "request" : "/my/index.php/another/deeper/path?time=day&duration=week",
+        "sessionid" : "9842abcdef",
+        "scripttype" : 2,
+        "created" : 1638244603,
+        "duration" : 0.153,
+        "resposnecode" : 200,
+        "cookies" : 1,
+        "buffering" : 1,
+        "fullname" : "Admin User",
+        "userlink" : "https://some.domain://user/profile?id=1',
+        "tabs" : "<ul></ul>"
+    }
+}}
+
+{{> core/tabtree}}
+<h3>{{{responsecode}}} {{method}} {{{request}}}</h3>
+<p>{{{delete_button}}} {{{delete_all_button}}}</p>
+
+<div id="profile-stats" class="container">
+    <div class="row">
+        <div class="">
+            <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
+                <tr>
+                    <th>{{#str}} field_contenttype, tool_excimer {{/str}}</th>
+                        <td>
+                        <span title="{{#str}} field_contenttypecategory, tool_excimer {{/str}}">{{contenttypecategory}}</span>
+                        -
+                        <span title="{{#str}} field_contenttypekey, tool_excimer {{/str}}">.{{contenttypekey}}</span>
+                        -
+                        <span title="{{#str}} field_contenttypevalue, tool_excimer {{/str}}">{{contenttypevalue}}</span>
+                    </td>
+                </tr>
+
+                <tr>
+                    <th>{{#str}} field_sessionid, tool_excimer {{/str}}</th>
+                    <td>{{sessionid}}...</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_reason, tool_excimer {{/str}}</th>
+                    <td>{{#reason_display}}{{reason}}{{/reason_display}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_scripttype, tool_excimer {{/str}}</th>
+                    <td>{{#script_type_display}}{{scripttype}}{{/script_type_display}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_created, tool_excimer {{/str}}</th>
+                    <td>{{#userdate}} {{created}}, {{#str}} strftimedaydatetime, langconfig {{/str}} {{/userdate}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_finished, tool_excimer {{/str}}</th>
+                    <td>
+                        {{#finished}}
+                            {{#userdate}} {{finished}}, {{#str}} strftimedaydatetime, langconfig {{/str}} {{/userdate}}
+                        {{/finished}}
+                        {{^finished}}
+                            {{#str}} didnotfinish, tool_excimer {{/str}}
+                        {{/finished}}
+                    </td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_duration, tool_excimer {{/str}}</th>
+                    <td>{{{duration}}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_numsamples, tool_excimer {{/str}}</th>
+                    <td>{{numsamples}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_dbreadwrites, tool_excimer {{/str}}</th>
+                    <td>{{dbreads}}/{{dbwrites}}</td>
+                </tr>
+            </table>
+        </div>
+        <div class="">
+            <table class="flexible table table-striped table-sm table-hover generaltable generalbox w-auto">
+                <tr>
+                    <th>{{#str}} field_datasize, tool_excimer {{/str}}</th>
+                    <td>{{datasize}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_cookies, tool_excimer {{/str}}</th>
+                    <td>{{#cookies}} {{#str}} yes, core_customfield {{/str}} {{/cookies}}{{^cookies}}{{#str}} no, core_customfield {{/str}}{{/cookies}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_buffering, tool_excimer {{/str}}</th>
+                    <td>{{#buffering}} {{#str}} yes, core_customfield {{/str}} {{/buffering}}{{^buffering}}{{#str}} no, core_customfield {{/str}}{{/buffering}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_userid, tool_excimer {{/str}}</th>
+                    <td>{{#userlink}}<a href="{{userlink}}">{{fullname}}</a>{{/userlink}}
+                        {{^userlink}}{{fullname}}{{/userlink}}</td>
+                </tr>
+
+                <tr>
+                    <th>{{#str}} field_pid, tool_excimer {{/str}}</th>
+                    <td>{{pid}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_hostname, tool_excimer {{/str}}</th>
+                    <td>{{hostname}}</td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_useragent, tool_excimer {{/str}}</th>
+                    <td><span title="{{useragent}}">{{#shortentext}} 20,{{useragent}} {{/shortentext}}</span></td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_versionhash, tool_excimer {{/str}}</th>
+                    <td><span title="{{versionhash}}">{{#shortentext}} 20,{{versionhash}} {{/shortentext}}</span></td>
+                </tr>
+                <tr>
+                    <th>{{#str}} field_dbreplicareads, tool_excimer {{/str}}</th>
+                    <td>{{dbreplicareads}}</td>
+                </tr>
+
+            </table>
+        </div>
+    </div>
+</div>

--- a/templates/profile.mustache
+++ b/templates/profile.mustache
@@ -115,6 +115,10 @@
                     <th>{{#str}} field_dbreadwrites, tool_excimer {{/str}}</th>
                     <td>{{dbreads}}/{{dbwrites}}</td>
                 </tr>
+                <tr>
+                    <th>{{#str}} field_memoryusagemax, tool_excimer {{/str}}</th>
+                    <td>{{memoryusagemax}}</td>
+                </tr>
             </table>
         </div>
         <div class="">
@@ -157,7 +161,6 @@
                     <th>{{#str}} field_dbreplicareads, tool_excimer {{/str}}</th>
                     <td>{{dbreplicareads}}</td>
                 </tr>
-
             </table>
         </div>
     </div>

--- a/tests/tool_excimer_cron_processor_test.php
+++ b/tests/tool_excimer_cron_processor_test.php
@@ -80,7 +80,7 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         $processor->on_interval($manager);
 
         $this->assertEquals($started + ($period * 1), $processor->sampletime);
-        $this->assertNull($processor->currenttask);
+        $this->assertNull($processor->tasksampleset);
 
         // Adding 3 more samples.
         $profiler = $this->get_profiler_stub([
@@ -94,9 +94,9 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         $this->assertEquals($started + ($period * 4), $processor->sampletime);
 
         // There should be a current sample set being recorded.
-        $this->assertNotNull($processor->currenttask);
-        $this->assertEquals($started + ($period * 2), $processor->currenttask->starttime);
-        $this->assertEquals(2, count($processor->currenttask->samples));
+        $this->assertNotNull($processor->tasksampleset);
+        $this->assertEquals($started + ($period * 2), $processor->tasksampleset->starttime);
+        $this->assertEquals(2, count($processor->tasksampleset->samples));
 
         // Adding four more samples. Should record two sample sets into the database.
         $profiler = $this->get_profiler_stub([
@@ -111,7 +111,7 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         $this->assertEquals($started + ($period * 8), $processor->sampletime);
 
         // There should not be a current sample set.
-        $this->assertNull($processor->currenttask);
+        $this->assertNull($processor->tasksampleset);
 
         // Check to see if the tasks have been recorded.
         $records = array_values($DB->get_records(profile::TABLE, null, 'created'));

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022041300;
-$plugin->release = 2022041300;
+$plugin->version = 2022041301;
+$plugin->release = 2022041301;
 
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022041301;
-$plugin->release = 2022041301;
+$plugin->version = 2022041300;
+$plugin->release = 2022041300;
 
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022040802;
-$plugin->release = 2022040802;
+$plugin->version = 2022041300;
+$plugin->release = 2022041300;
 
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 


### PR DESCRIPTION
- refactor: adjust sample_set class to not require 3rd param by default
- feat: add memusage graph and split sections making it more maintainable
- feat: add memusage storage during batch processing
- fix: line chart display
- fix: amount of memory usage samples shown on the x-axis
- style: cleanup usage in web processor and for json endpoint
- style: further cleanup of cron and web processor files
- feat: add memoryusage sampleset handling to cron processor
- feat: add max memory usage field to be stored on profile save


- [x] Clean up template file descriptions
- [x] Rebase and correct versioning, probably compact the changes into one savepoint.


Example: a long running sleeping web request (e.g. with sleeps at the end)

![image](https://user-images.githubusercontent.com/9924643/162687020-24e3f522-dc21-4126-bf8e-7af088bfbfbd.png)


Related to #173 (not does not completely close it)