### PR TITLE
WIP: Issue #174: Detect and action recursive tasks #199

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -147,7 +147,8 @@ class cron_processor implements processor {
         $reasonstack = 0;
         $duration = $finishtime - $this->currenttask->starttime;
 
-        if ($this->currentstack && $this->currenttask->get_stack_depth() > script_metadata::get_stack_limit()) {
+        if (property_exists($this, 'currentstack') && $this->currentstack
+                && $this->currenttask->get_stack_depth() > script_metadata::get_stack_limit()) {
             $reasonstack = profile::REASON_STACK;
         }
         $profile = new profile();

--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -147,7 +147,7 @@ class cron_processor implements processor {
         $reasonstack = 0;
         $duration = $finishtime - $this->currenttask->starttime;
 
-        if (property_exists($this, 'currentstack') && $this->currentstack
+        if (property_exists($this, 'currenttask') && $this->currenttask
                 && $this->currenttask->get_stack_depth() > script_metadata::get_stack_limit()) {
             $reasonstack = profile::REASON_STACK;
         }

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -81,6 +81,9 @@ class helper {
         if ($reason & profile::REASON_FLAMEME) {
             $reasonsmatched[] = get_string('reason_flameme', 'tool_excimer');
         }
+        if ($reason & profile::REASON_STACK) {
+            $reasonsmatched[] = get_string('reason_stack', 'tool_excimer');
+        }
         return implode(',', $reasonsmatched);
     }
 

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -221,6 +221,7 @@ class profile extends persistent {
             'parameters' => ['type' => PARAM_TEXT, 'default' => ''],
             'sessionid' => ['type' => PARAM_ALPHANUM, 'default' => ''],
             'userid' => ['type' => PARAM_INT, 'default' => 0],
+            'maxstackdepth' => ['type' => PARAM_INT, 'default' => 0],
             'cookies' => ['type' => PARAM_BOOL],
             'buffering' => ['type' => PARAM_BOOL],
             'responsecode' => ['type' => PARAM_INT, 'default' => 0],

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -43,18 +43,23 @@ class profile extends persistent {
     /** Reason - FLAMEALL - Toggles profiling for all subsequent pages, until FLAMEALLSTOP param is passed as a page param. */
     const REASON_FLAMEALL = 0b0100;
 
+    /** Reason - STACK - Set when maxstackdepth exceeds a predefined limit. */
+    const REASON_STACK = 0b1000;
+
 
     /** Reasons for profiling (bitmask flags). NOTE: Excluding the NONE option intentionally. */
     const REASONS = [
         self::REASON_FLAMEME,
         self::REASON_SLOW,
         self::REASON_FLAMEALL,
+        self::REASON_STACK,
     ];
 
     const REASON_STR_MAP = [
         self::REASON_FLAMEME => 'manual',
         self::REASON_SLOW => 'slowest',
         self::REASON_FLAMEALL => 'flameall',
+        self::REASON_STACK => 'stackdepth',
     ];
 
     const SCRIPTTYPE_AJAX = 0;

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -146,6 +146,7 @@ class profile_table extends \table_sql {
             'responsecode',
             'referer',
             'userid',
+            'maxstackdepth',
             'lang',
             'firstname',
             'lastname',

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -32,6 +32,7 @@ class sample_set {
     public $samples = [];
 
     public $samplelimit;
+    public $maxstackdepth = 0;
 
     /** @var int If $filterrate is R, then only each Rth sample is recorded. */
     private $filterrate = 1;
@@ -65,6 +66,18 @@ class sample_set {
         if ($this->counter === $this->filterrate) {
             $this->samples[] = $sample;
             $this->counter = 0;
+        }
+        // Each time a sample is added, recalculate the maxstackdepth for this set.
+        if ($this->samples) {
+            foreach ($this->samples as $sample) {
+                $trace = $sample->getTrace();
+                if ($trace) {
+                    $stackdepth = count($trace);
+                    if ($stackdepth > $this->maxstackdepth) {
+                        $this->maxstackdepth = $stackdepth;
+                    }
+                }
+            }
         }
     }
 

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -54,6 +54,17 @@ class sample_set {
     }
 
     /**
+     * Return the stack depth for this set.
+     *
+     * @param \ExcimerLogEntry $sample
+     * @return void
+     */
+
+    public function get_stack_depth() : int {
+        return $this->maxstackdepth;
+    }
+
+    /**
      * Add a sample to the sample store, applying any filters.
      *
      * @param array $sample

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -68,14 +68,12 @@ class sample_set {
             $this->counter = 0;
         }
         // Each time a sample is added, recalculate the maxstackdepth for this set.
-        if ($this->samples) {
-            foreach ($this->samples as $sample) {
-                $trace = $sample->getTrace();
-                if ($trace) {
-                    $stackdepth = count($trace);
-                    if ($stackdepth > $this->maxstackdepth) {
-                        $this->maxstackdepth = $stackdepth;
-                    }
+        foreach ($this->samples as $sample) {
+            $trace = $sample->getTrace();
+            if ($trace) {
+                $stackdepth = count($trace);
+                if ($stackdepth > $this->maxstackdepth) {
+                    $this->maxstackdepth = $stackdepth;
                 }
             }
         }

--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -68,6 +68,8 @@ class script_metadata {
     const TIMER_INTERVAL_MIN = 1;
     const TIMER_INTERVAL_DEFAULT = 10;
 
+    const STACK_DEPTH_LIMIT = 1000;
+
     const SAMPLE_LIMIT_DEFAULT = 1024;
 
     /**
@@ -344,5 +346,18 @@ class script_metadata {
             return self::SAMPLE_LIMIT_DEFAULT;
         }
         return $limit;
+    }
+
+    /**
+     * Returns the pre-configured stack (recursion) limit.
+     *
+     * @return integer
+     */
+    public static function get_stack_limit(): int {
+        $depth = (int) get_config('tool_excimer', 'stacklimit');
+        if ($depth <= 0) {
+            return self::STACK_DEPTH_LIMIT;
+        }
+        return $depth;
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20220408" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20220412" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,6 +19,7 @@
         <FIELD NAME="parameters" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Request variables or command arguments"/>
         <FIELD NAME="sessionid" TYPE="char" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Session ID"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="User ID"/>
+        <FIELD NAME="maxstackdepth" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Maximum stack depth across all samples"/>
         <FIELD NAME="cookies" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Are any cookies set?"/>
         <FIELD NAME="buffering" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Is buffering set?"/>
         <FIELD NAME="responsecode" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="HTTP response code, or 0/1 for command line"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -286,5 +286,17 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022040802, 'tool', 'excimer');
     }
 
+    if ($oldversion < 2022041200) {
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('maxstackdepth', XMLDB_TYPE_INTEGER, '11', null, XMLDB_NOTNULL, null, 0, 'userid');
+
+        if ($dbman->table_exists($table) && $dbman->field_exists($table, $field)) {
+            $dbman->change_field_type($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022041200, 'tool', 'excimer');
+    }
+
     return true;
 }

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -73,6 +73,8 @@ $string['samplelimit_desc'] = 'The maximum number of samples that will be record
     samples. Each time the limit is reached, the samples recorded so far are stripped of every second sample. Also, the filter rate
     doubles, so that only every Nth sample is recorded at filter rate N. This has the same effect as adjusting the sampling period
     so that the total number of samples never exceeds the limit.';
+$string['stacklimit'] = 'Stack limit';
+$string['stacklimit_desc'] = 'The maximum permitted recursion or stack depth before the task is flagged.';
 
 // Tabs.
 $string['slowest_grouped'] = 'Slowest scripts';
@@ -137,6 +139,7 @@ $string['reason_flameme'] = 'Flame Me';
 $string['reason_auto'] = 'Auto';
 $string['reason_slow'] = 'Slow';
 $string['reason_flameall'] = 'Flame All';
+$string['reason_stack'] = 'Recursion';
 
 // Time formats.
 $string['strftime_datetime'] = '%d %b %Y, %H:%M';

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022040802;
-$plugin->release = 2022040802;
+$plugin->version = 2022041200;
+$plugin->release = 2022041200;
 
 $plugin->requires = 2019052006;    // Our lowest supported Moodle (3.7.6).
 


### PR DESCRIPTION
WIP: Issue https://github.com/catalyst/moodle-tool_excimer/issues/174 ; Detect recursive tasks

- DB field added 'maxstackdepth' with DB migration tasks [done]
- Calculate the deepest stack depth for each sample set [done]
- flag the resulting profile as "interesting" if the stack depth exceeds a defined minimum. [done]
- optionally(?) kill the offending task [in progress]