### PR TITLE
Fix flamegraph distribution of stack events & # of samples stored/shown in the details

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -168,7 +168,7 @@ class cron_processor implements processor {
             $profile->set('finished', (int) $finishtime);
             $profile->set('memoryusagedatad3', $this->memoryusagesampleset->samples);
             $profile->set('flamedatad3', flamed3_node::from_excimer_log_entries($this->tasksampleset->samples));
-            $profile->set('numsamples', $this->tasksampleset->total_added());
+            $profile->set('numsamples', $this->tasksampleset->count());
             $profile->set('samplerate', $this->tasksampleset->filter_rate() * get_config('tool_excimer', 'sample_ms'));
             $profile->save_record();
         }

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -70,6 +70,12 @@ class sample_set {
             $this->samples[] = $sample;
             $this->counter = 0;
         }
+        // If this is a log entry, it will count the number of total events
+        // processed instead.
+        if ($sample instanceof \ExcimerLogEntry) {
+            $this->totaladded += $sample->getEventCount();
+            return;
+        }
         $this->totaladded++;
     }
 
@@ -108,18 +114,29 @@ class sample_set {
     /**
      * Number of samples that have gone through the add_sample method
      *
-     * @return    int number of samples added
+     * @return int number of samples added
      */
     public function total_added() {
         return $this->totaladded;
     }
 
     /**
-     * Number of samples currently in possession
+     * Number of real samples, that is currently in possession.
      *
-     * @return    int count of $this->samples
+     * This is the total sum of events. Noting that the filtering, if required,
+     * will have a reduced amount when compared to the totaladded count.
+     *
+     * @return int count of $this->samples
      */
     public function count() {
+        if (isset($this->samples[0]) instanceof \ExcimerLogEntry) {
+            $count = array_reduce($this->samples, function($acc, $sample) {
+                $acc += $sample->getEventCount();
+                return $acc;
+            }, 0);
+            return $count;
+        }
+
         return count($this->samples);
     }
 

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -101,7 +101,7 @@ class web_processor implements processor {
             $this->profile->set('finished', $isfinal ? (int) $current : 0);
             $this->profile->set('memoryusagedatad3', $this->memoryusagesampleset->samples);
             $this->profile->set('flamedatad3', flamed3_node::from_excimer_log_entries($this->sampleset->samples));
-            $this->profile->set('numsamples', $this->sampleset->total_added());
+            $this->profile->set('numsamples', $this->sampleset->count());
             $this->profile->set('samplerate', $this->sampleset->filter_rate() * get_config('tool_excimer', 'sample_ms'));
             $this->profile->save_record();
         }


### PR DESCRIPTION
- fix: flamegraph processing to correctly show the event size of each node
- fix: sample events now correctly tallied

![image](https://user-images.githubusercontent.com/9924643/163322635-c53d3a76-77a1-4fe3-9512-89b66b453c05.png)

==

Process for future reference:

I did a bisect which allowed me to see when it was last in a good state.
```
$ git bisect log
git bisect start
# bad: [6bb4d5953a2413fb3401554fa362ce4af428b12a] Issue #158: Added check for needing to upgrade. (#159)
git bisect bad 6bb4d5953a2413fb3401554fa362ce4af428b12a
# good: [1dd47c4505edf11a0bee2d6af08f1d5ad0de74cf] Add display to dbreplicareads field to profile
git bisect good 1dd47c4505edf11a0bee2d6af08f1d5ad0de74cf
# bad: [03a00d233e6fc42f356b9aa3d5e13a0329889684] Issue #146:
git bisect bad 03a00d233e6fc42f356b9aa3d5e13a0329889684
# good: [fac380c0af751aca83e0114b53bec8ba6a4f9bbb] Issue #131: Added D3 and d3-flame-graph third party libraries. (#140)
git bisect good fac380c0af751aca83e0114b53bec8ba6a4f9bbb
# bad: [8e63af7de22a32e3bb139379b76546a056626441] Issue #141: JS inclusion on profile page is done through Page API. (#145)
git bisect bad 8e63af7de22a32e3bb139379b76546a056626441
# bad: [d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb] Issue 25 wip (#137)
git bisect bad d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb
# first bad commit: [d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb] Issue 25 wip (#137)
```
Then I looked through the differences between the commit and the previous one to it here: https://github.com/catalyst/moodle-tool_excimer/compare/d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb~..d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb#

In particular, I looked here: https://github.com/catalyst/moodle-tool_excimer/blob/d374ca0b99129e5fdfdd3aca1536c8ac9d9dbdeb~/classes/profile.php and saw that the d3 flame graph was being processed in a different format, in particular using `$log->formatCollapsed(). 

Checking this I outputted what the would be result is, here's a small snippet:
```
;/var/www/39/report/customsql/view.php;report_customsql_log_view;core\event\base::trigger;core\event\base::validate_before_trigger;database_manager::table_exists;sql_generator::table_exists;pgsql_native_moodle_database::get_tables 1
;/var/www/39/report/customsql/view.php;report_customsql_generate_csv;report_customsql_execute_query;pgsql_native_moodle_database::get_recordset_sql 401
;/var/www/39/report/customsql/view.php;report_customsql_generate_csv;pgsql_native_moodle_database::update_record;pgsql_native_moodle_database::update_record_raw 1
```

I noticed the number 401 was odd, and seemed to coincide with the duration of my test (~4 seconds of wait time), so I ended up finding out the issue was that it was missing handling for the event count/size, and was setting everything to 1 by default.



https://github.com/catalyst/moodle-tool_excimer/issues/204