### PR TITLE
Issue #174: Detect and action recursive tasks

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -16,6 +16,8 @@
 
 namespace tool_excimer;
 
+use tool_excimer\script_metadata;
+
 /**
  * Class for processing cron and adhoc tasks.
  *
@@ -162,6 +164,7 @@ class cron_processor implements processor {
         $profile->add_env($this->tasksampleset->name);
         $profile->set('created', (int) $this->tasksampleset->starttime);
         $profile->set('duration', $duration);
+        $profile->set('maxstackdepth', $this->tasksampleset->get_stack_depth());
         $reasons = $manager->get_reasons($profile);
         if ($reasons !== profile::REASON_NONE) {
             $profile->set('reason', $reasons);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -81,6 +81,9 @@ class helper {
         if ($reason & profile::REASON_FLAMEME) {
             $reasonsmatched[] = get_string('reason_flameme', 'tool_excimer');
         }
+        if ($reason & profile::REASON_STACK) {
+            $reasonsmatched[] = get_string('reason_stack', 'tool_excimer');
+        }
         return implode(',', $reasonsmatched);
     }
 

--- a/classes/manager.php
+++ b/classes/manager.php
@@ -176,6 +176,9 @@ class manager {
     public function get_reasons(profile $profile): int {
         global $SESSION;
         $reason = profile::REASON_NONE;
+        if ((int) $profile->get('maxstackdepth') > (int) script_metadata::get_stack_limit()) {
+            $reason |= profile::REASON_STACK;
+        }
         if (self::is_flag_set(self::FLAME_ME_PARAM_NAME)) {
             $reason |= profile::REASON_FLAMEME;
         }

--- a/classes/profile.php
+++ b/classes/profile.php
@@ -43,18 +43,23 @@ class profile extends persistent {
     /** Reason - FLAMEALL - Toggles profiling for all subsequent pages, until FLAMEALLSTOP param is passed as a page param. */
     const REASON_FLAMEALL = 0b0100;
 
+    /** Reason - STACK - Set when maxstackdepth exceeds a predefined limit. */
+    const REASON_STACK = 0b1000;
+
 
     /** Reasons for profiling (bitmask flags). NOTE: Excluding the NONE option intentionally. */
     const REASONS = [
         self::REASON_FLAMEME,
         self::REASON_SLOW,
         self::REASON_FLAMEALL,
+        self::REASON_STACK,
     ];
 
     const REASON_STR_MAP = [
         self::REASON_FLAMEME => 'manual',
         self::REASON_SLOW => 'slowest',
         self::REASON_FLAMEALL => 'flameall',
+        self::REASON_STACK => 'stackdepth',
     ];
 
     const SCRIPTTYPE_AJAX = 0;
@@ -293,6 +298,7 @@ class profile extends persistent {
             'parameters' => ['type' => PARAM_TEXT, 'default' => ''],
             'sessionid' => ['type' => PARAM_ALPHANUM, 'default' => ''],
             'userid' => ['type' => PARAM_INT, 'default' => 0],
+            'maxstackdepth' => ['type' => PARAM_INT, 'default' => 0],
             'cookies' => ['type' => PARAM_BOOL],
             'buffering' => ['type' => PARAM_BOOL],
             'responsecode' => ['type' => PARAM_INT, 'default' => 0],

--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -146,6 +146,7 @@ class profile_table extends \table_sql {
             'responsecode',
             'referer',
             'userid',
+            'maxstackdepth',
             'lang',
             'firstname',
             'lastname',

--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -68,6 +68,8 @@ class script_metadata {
     const TIMER_INTERVAL_MIN = 1;
     const TIMER_INTERVAL_DEFAULT = 10;
 
+    const STACK_DEPTH_LIMIT = 1000;
+
     const SAMPLE_LIMIT_DEFAULT = 1024;
 
     /**
@@ -344,5 +346,19 @@ class script_metadata {
             return self::SAMPLE_LIMIT_DEFAULT;
         }
         return $limit;
+    }
+
+    /**
+     * Returns the pre-configured stack (recursion) limit.
+     *
+     * @return integer
+     */
+    public static function get_stack_limit(): int {
+        $depth = (int) get_config('tool_excimer', 'stacklimit');
+        if ($depth <= 0) {
+            set_config('stacklimit', self::STACK_DEPTH_LIMIT, 'tool_excimer');
+            return self::STACK_DEPTH_LIMIT;
+        }
+        return $depth;
     }
 }

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -95,6 +95,7 @@ class web_processor implements processor {
         ]);
         $current = microtime(true);
         $this->profile->set('duration', $current - $manager->get_starttime());
+        $this->profile->set('maxstackdepth', $this->sampleset->get_stack_depth());
         $reason = $manager->get_reasons($this->profile);
         if ($reason !== profile::REASON_NONE) {
             $this->profile->set('reason', $reason);

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20220413" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20220420" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,6 +19,7 @@
         <FIELD NAME="parameters" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Request variables or command arguments"/>
         <FIELD NAME="sessionid" TYPE="char" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Session ID"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="User ID"/>
+        <FIELD NAME="maxstackdepth" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Maximum stack depth across all samples"/>
         <FIELD NAME="cookies" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Are any cookies set?"/>
         <FIELD NAME="buffering" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Is buffering set?"/>
         <FIELD NAME="responsecode" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="HTTP response code, or 0/1 for command line"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -324,5 +324,18 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         // Excimer savepoint reached.
         upgrade_plugin_savepoint(true, 2022041301, 'tool', 'excimer');
     }
+
+    if ($oldversion < 2022042000) {
+        // Add field maxstackdepth.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('maxstackdepth', XMLDB_TYPE_INTEGER, '11', null, XMLDB_NOTNULL, null, 0, 'userid');
+
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022042000, 'tool', 'excimer');
+    }
     return true;
 }

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -73,6 +73,8 @@ $string['samplelimit_desc'] = 'The maximum number of samples that will be record
     samples. Each time the limit is reached, the samples recorded so far are stripped of every second sample. Also, the filter rate
     doubles, so that only every Nth sample is recorded at filter rate N. This has the same effect as adjusting the sampling period
     so that the total number of samples never exceeds the limit.';
+$string['stacklimit'] = 'Stack limit';
+$string['stacklimit_desc'] = 'The maximum permitted recursion or stack depth before the task is flagged.';
 
 // Tabs.
 $string['slowest_grouped'] = 'Slowest scripts';
@@ -139,6 +141,7 @@ $string['reason_flameme'] = 'Flame Me';
 $string['reason_auto'] = 'Auto';
 $string['reason_slow'] = 'Slow';
 $string['reason_flameall'] = 'Flame All';
+$string['reason_stack'] = 'Recursion';
 
 // Time formats.
 $string['strftime_datetime'] = '%d %b %Y, %H:%M';

--- a/settings.php
+++ b/settings.php
@@ -102,6 +102,17 @@ if ($hassiteconfig) {
         );
 
         $settings->add(
+            new admin_setting_configtext(
+                'tool_excimer/stacklimit',
+                get_string('stacklimit', 'tool_excimer'),
+                get_string('stacklimit_desc', 'tool_excimer'),
+                '1000',
+                PARAM_INT
+            )
+        );
+
+
+        $settings->add(
             new admin_setting_configduration(
                 'tool_excimer/expiry_s',
                 get_string('expiry_s', 'tool_excimer'),

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022041301;
-$plugin->release = 2022041301;
+$plugin->version = 2022042000;
+$plugin->release = 2022042000;
 
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 


### PR DESCRIPTION
Issue #174: Detect and action recursive tasks
  - DB field added 'maxstackdepth' with DB migration tasks [done]
  - Calculate the deepest stack depth for each sample set [done]
  - flag the resulting profile as "interesting" if the stack depth exceeds a defined minimum. [done]