### PR TITLE
excimer #142; check existence of query string

### DIFF
--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -107,9 +107,12 @@ class script_metadata {
             return $parameters;
         }
 
-        $parameters = [];
-        parse_str($_SERVER['QUERY_STRING'], $parameters);
-        return http_build_query(self::stripparameters($parameters), '', '&');
+        if (isset($_SERVER['QUERY_STRING'])) {
+            $parameters = [];
+            parse_str($_SERVER['QUERY_STRING'], $parameters);
+            return http_build_query(self::stripparameters($parameters), '', '&');
+        }
+        return '';
     }
 
     /**


### PR DESCRIPTION
This just checks the existence of $_SERVER['QUERY_STRING'] before accessing it and returns an empty string if the condition falls through. 