### PR TITLE
Issue #227; excimer field modification to ensure DB consistency.

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/excimer/db" VERSION="20220420" COMMENT="XMLDB file for Moodle admin/tool/excimer"
+<XMLDB PATH="admin/tool/excimer/db" VERSION="20220427" COMMENT="XMLDB file for Moodle admin/tool/excimer"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -19,7 +19,7 @@
         <FIELD NAME="parameters" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Request variables or command arguments"/>
         <FIELD NAME="sessionid" TYPE="char" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Session ID"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="User ID"/>
-        <FIELD NAME="maxstackdepth" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="Maximum stack depth across all samples"/>
+        <FIELD NAME="maxstackdepth" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Maximum stack depth across all samples"/>
         <FIELD NAME="cookies" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Are any cookies set?"/>
         <FIELD NAME="buffering" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Is buffering set?"/>
         <FIELD NAME="responsecode" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="HTTP response code, or 0/1 for command line"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -337,5 +337,20 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         // Excimer savepoint reached.
         upgrade_plugin_savepoint(true, 2022042000, 'tool', 'excimer');
     }
+
+    if ($oldversion < 2022042700) {
+        // Modify field maxstackdepth.
+        $table = new xmldb_table('tool_excimer_profiles');
+        $field = new xmldb_field('maxstackdepth', XMLDB_TYPE_INTEGER, '11', null, XMLDB_NOTNULL, null, 0, 'userid');
+
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_default($table, $field);
+        } else {
+            $dbman->add_field($table, $field);
+        }
+
+        // Excimer savepoint reached.
+        upgrade_plugin_savepoint(true, 2022042700, 'tool', 'excimer');
+    }
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -23,8 +23,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022042000;
-$plugin->release = 2022042000;
+$plugin->version = 2022042700;
+$plugin->release = 2022042700;
 
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 


### PR DESCRIPTION
Issue #227; excimer field modification to ensure DB consistency.
Field 'maxstackdepth' created with no default but added with a default.
This checkin ensures that if the field exists already with no default
that it will be modifed to set default to 0.