### PR TITLE
Issue #299: Fix bug causing insert ID error

### DIFF
--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -83,6 +83,32 @@ class script_metadata {
     /** Default sample limit. */
     const SAMPLE_LIMIT_DEFAULT = 1024;
 
+    /** @var int Stack limit config. */
+    protected static $stacklimit;
+    /** @var int Sample limit config. */
+    protected static $samplelimit;
+    /** @var int Sampling period */
+    public static $samplems;
+    /** @var string */
+    protected static $redactparams;
+
+    /**
+     * Preload config values to avoid DB access during processing. See manager::get_altconnection() for more information.
+     */
+    public static function init() {
+        self::$stacklimit = (int) get_config('tool_excimer', 'stacklimit');
+        if (self::$stacklimit <= 0) {
+            self::$stacklimit = self::STACK_DEPTH_LIMIT;
+        }
+
+        self::$samplelimit = (int) get_config('tool_excimer', 'samplelimit');
+        if (self::$samplelimit <= 0) {
+            self::$samplelimit = self::SAMPLE_LIMIT_DEFAULT;
+        }
+        self::$samplems = get_config('tool_excimer', 'sample_ms');
+        self::$redactparams = get_config('tool_excimer', 'redact_params');
+    }
+
     /**
      * Gets the script type of the request.
      *
@@ -157,10 +183,8 @@ class script_metadata {
      * @return string[]
      */
     public static function get_redactable_param_names(): array {
-        $setting = get_config('tool_excimer', 'redact_params');
-
         // Strip C style comments.
-        $setting = preg_replace('!/\*.*?\*/!s', '', $setting);
+        $setting = preg_replace('!/\*.*?\*/!s', '', self::$redactparams);
 
         $lines = explode(PHP_EOL, $setting);
 
@@ -400,11 +424,7 @@ class script_metadata {
      * @throws \dml_exception
      */
     public static function get_sample_limit(): int {
-        $limit = (int) get_config('tool_excimer', 'samplelimit');
-        if ($limit <= 0) {
-            return self::SAMPLE_LIMIT_DEFAULT;
-        }
-        return $limit;
+        return self::$samplelimit;
     }
 
     /**
@@ -413,11 +433,6 @@ class script_metadata {
      * @return integer
      */
     public static function get_stack_limit(): int {
-        $depth = (int) get_config('tool_excimer', 'stacklimit');
-        if ($depth <= 0) {
-            set_config('stacklimit', self::STACK_DEPTH_LIMIT, 'tool_excimer');
-            return self::STACK_DEPTH_LIMIT;
-        }
-        return $depth;
+        return self::$stacklimit;
     }
 }

--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -36,6 +36,20 @@ class web_processor implements processor {
     /** @var sample_set */
     protected $memoryusagesampleset;
 
+    /** @var int */
+    protected $minduration;
+    /** @var int */
+    protected $samplems;
+
+    /**
+     * Construct the web processor.
+     */
+    public function __construct() {
+        // Preload config values to avoid DB access during processing. See manager::get_altconnection() for more information.
+        $this->minduration = (float) get_config('tool_excimer', 'trigger_ms') / 1000.0;
+        $this->samplems = (int) get_config('tool_excimer', 'sample_ms');
+    }
+
     /**
      * Initialises the processor
      *
@@ -79,7 +93,7 @@ class web_processor implements processor {
      * @return float
      */
     public function get_min_duration(): float {
-        return (float) get_config('tool_excimer', 'trigger_ms') / 1000.0;
+        return $this->minduration;
     }
 
     /**
@@ -107,7 +121,7 @@ class web_processor implements processor {
             $this->profile->set('memoryusagedatad3', $this->memoryusagesampleset->samples);
             $this->profile->set('flamedatad3', flamed3_node::from_excimer_log_entries($this->sampleset->samples));
             $this->profile->set('numsamples', $this->sampleset->count());
-            $this->profile->set('samplerate', $this->sampleset->filter_rate() * get_config('tool_excimer', 'sample_ms'));
+            $this->profile->set('samplerate', $this->sampleset->filter_rate() * $this->samplems);
             $this->profile->save_record();
         }
     }

--- a/tests/tool_excimer_cron_processor_test.php
+++ b/tests/tool_excimer_cron_processor_test.php
@@ -67,6 +67,7 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         global $DB;
         $this->preventResetByRollback();
 
+        script_metadata::init();
         $processor = new cron_processor();
         $timer = new \ExcimerTimer();
 
@@ -135,4 +136,3 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         $this->assertEquals(1, $records[1]->numsamples);
     }
 }
-

--- a/tests/tool_excimer_profile_helper_test.php
+++ b/tests/tool_excimer_profile_helper_test.php
@@ -33,6 +33,8 @@ class tool_excimer_profile_helper_test extends \advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
+        profile_helper::init();
+        script_metadata::init();
     }
 
     /**
@@ -408,6 +410,8 @@ class tool_excimer_profile_helper_test extends \advanced_testcase {
         set_config('num_slowest', 4, 'tool_excimer'); // 5 max slowest
         set_config('trigger_ms', 2, 'tool_excimer'); // Should capture anything at least 1ms slow.
         get_config('tool_excimer', 'trigger_ms');
+
+        profile_helper::init();
 
         // Emulate a scenario where all breakpoints are met (request quota, system quota, etc).
         $startreads = $DB->perf_get_reads();

--- a/tests/tool_excimer_sample_set_test.php
+++ b/tests/tool_excimer_sample_set_test.php
@@ -177,6 +177,7 @@ class tool_excimer_sample_set_test extends excimer_testcase {
      * @covers \tool_excimer\sample_set::add_many_samples
      */
     public function test_event_count() {
+        script_metadata::init();
         $eventcounts = [1, 1, 4, 1, 2, 1];
         $samples1 = [
             $this->get_log_entry_stub(['a'], 0, $eventcounts[0]),

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -45,6 +45,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      */
     public function test_strip_parameters(string $config, array $params, array $expected) {
         set_config('redact_params', $config, 'tool_excimer');
+        script_metadata::init();
         $this->assertEquals($expected, script_metadata::strip_parameters($params));
     }
 
@@ -89,6 +90,8 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
     public function test_get_parameters(string $querystring, string $expected) {
         global $ME;
 
+        script_metadata::init();
+
         $globalme = $ME ?? null;
         $ME = 'abc.php?' . $querystring;
         $params = script_metadata::get_parameters(profile::SCRIPTTYPE_WEB);
@@ -131,6 +134,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param string $expected
      */
     public function test_get_groupby_value(string $request, string $pathinfo, string $parameters, string $expected) {
+        script_metadata::init();
         $profile = new profile();
         $profile->set('request', $request);
         $profile->set('pathinfo', $pathinfo);
@@ -165,6 +169,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
     public function test_get_sample_limit(int $limit, int $expected) {
         $this->preventResetByRollback();
         set_config('samplelimit', $limit, 'tool_excimer');
+        script_metadata::init();
         $this->assertEquals($expected, script_metadata::get_sample_limit());
     }
 
@@ -193,6 +198,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      */
     public function test_get_redactable_param_names(string $config, array $expected) {
         set_config('redact_params', $config, 'tool_excimer');
+        script_metadata::init();
         $this->assertEquals($expected, script_metadata::get_redactable_param_names());
     }
 


### PR DESCRIPTION
Resolves #299 

Remove all access to the database through the primary DB variable. Preload config values before processing.
Replace use of config caching with cache class.
Use alternative connection to access database during profile processing.