### PR TITLE
[#272] Fix for fuzzy grouping, function rename

### DIFF
--- a/classes/web_processor.php
+++ b/classes/web_processor.php
@@ -59,7 +59,9 @@ class web_processor implements processor {
         // Record and set initial memory usage at this point.
         $memoryusage = memory_get_usage();
 
-        $request = script_metadata::get_request();
+        global $ME, $SCRIPT;
+
+        $request = script_metadata::get_normalised_relative_script_path($ME, $SCRIPT);
         $starttime = (int) $manager->get_starttime();
         $this->sampleset = new sample_set($request, $starttime);
 

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -189,28 +189,6 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
     }
 
     /**
-     * Tests script_metadata::get_request().
-     * @dataProvider relative_script_path_provider
-     * @covers \tool_excimer\script_metadata::get_request
-     * @param string $path
-     * @param string $expected
-     */
-    public function test_get_request(string $path, string $expected) {
-        script_metadata::init();
-
-        global $SCRIPT, $ME;
-        $globalscript = $SCRIPT ?? null;
-        $globalme = $ME ?? null;
-
-        $SCRIPT = $path;
-        $ME = $path;
-        $this->assertEquals($expected, script_metadata::get_request());
-
-        $SCRIPT = $globalscript;
-        $ME = $globalme;
-    }
-
-    /**
      * Tests script_metadata::get_normalised_relative_script_path().
      * @dataProvider relative_script_path_provider
      * @covers \tool_excimer\script_metadata::get_normalised_relative_script_path
@@ -229,28 +207,28 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      */
     public function relative_script_path_provider(): array {
         return [
-            ['', ''],
-            ['/', ''],
-            ['//', ''],
-            ['///', ''],
+            ['', '/'],
+            ['/', '/'],
+            ['//', '/'],
+            ['///', '/'],
             ['home', 'home'],
             ['/home', 'home'],
-            ['home/', 'home/'],
-            ['/home/', 'home/'],
+            ['home/', 'home'],
+            ['/home/', 'home'],
             ['hello/world', 'hello/world'],
             ['/hello/world', 'hello/world'],
-            ['/hello/world/', 'hello/world/'],
-            ['/////hello////world///', 'hello////world///'],
-            ['/////hello////world/index.php', 'hello////world/index.php'],
-            ['/////hello////world///index.php', 'hello////world///index.php'],
-            ['/////hello////world/index.php///', 'hello////world/index.php'],
-            ['/index.php', 'index.php'],
-            ['/my//index.php////', 'my//index.php'],
-            ['/my//index.php////index.php', 'my//index.php'],
-            ['/my//index.php////index.php/', 'my//index.php'],
-            ['/my//index.php////index.php/hello/world?param=value&param2=value', 'my//index.php'],
-            ['https://example.com//index.php', 'https://example.com//index.php'],
-            ['https://example.com/index.php/', 'https://example.com/index.php'],
+            ['/hello/world/', 'hello/world'],
+            ['/////hello////world///', 'hello/world'],
+            ['/////hello////world/index.php', 'hello/world'],
+            ['/////hello////world///index.php', 'hello/world'],
+            ['/////hello////world/index.php///', 'hello/world'],
+            ['/index.php', '/'],
+            ['/my//index.php////', 'my'],
+            ['/my//index.php////index.php', 'my'],
+            ['/my//index.php////index.php/', 'my'],
+            ['/my//index.php////index.php/hello/world?param=value&param2=value', 'my'],
+            ['https://example.com//index.php', 'https:/example.com'],
+            ['https://example.com/index.php/', 'https:/example.com'],
         ];
     }
 

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -189,6 +189,72 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
     }
 
     /**
+     * Tests script_metadata::get_request().
+     * @dataProvider relative_script_path_provider
+     * @covers \tool_excimer\script_metadata::get_request
+     * @param string $path
+     * @param string $expected
+     */
+    public function test_get_request(string $path, string $expected) {
+        script_metadata::init();
+
+        global $SCRIPT, $ME;
+        $globalscript = $SCRIPT ?? null;
+        $globalme = $ME ?? null;
+
+        $SCRIPT = $path;
+        $ME = $path;
+        $this->assertEquals($expected, script_metadata::get_request());
+
+        $SCRIPT = $globalscript;
+        $ME = $globalme;
+    }
+
+    /**
+     * Tests script_metadata::get_normalised_relative_script_path().
+     * @dataProvider relative_script_path_provider
+     * @covers \tool_excimer\script_metadata::get_normalised_relative_script_path
+     * @param string $path
+     * @param string $expected
+     */
+    public function test_get_normalised_relative_script_path(string $path, string $expected) {
+        script_metadata::init();
+        $this->assertEquals($expected, script_metadata::get_normalised_relative_script_path($path, null));
+        $this->assertEquals($expected, script_metadata::get_normalised_relative_script_path(null, $path));
+    }
+
+    /**
+     * Provider for test_get_normalised_relative_script_path().
+     * @return \string[][]
+     */
+    public function relative_script_path_provider(): array {
+        return [
+            ['', ''],
+            ['/', ''],
+            ['//', ''],
+            ['///', ''],
+            ['home', 'home'],
+            ['/home', 'home'],
+            ['home/', 'home/'],
+            ['/home/', 'home/'],
+            ['hello/world', 'hello/world'],
+            ['/hello/world', 'hello/world'],
+            ['/hello/world/', 'hello/world/'],
+            ['/////hello////world///', 'hello////world///'],
+            ['/////hello////world/index.php', 'hello////world/index.php'],
+            ['/////hello////world///index.php', 'hello////world///index.php'],
+            ['/////hello////world/index.php///', 'hello////world/index.php'],
+            ['/index.php', 'index.php'],
+            ['/my//index.php////', 'my//index.php'],
+            ['/my//index.php////index.php', 'my//index.php'],
+            ['/my//index.php////index.php/', 'my//index.php'],
+            ['/my//index.php////index.php/hello/world?param=value&param2=value', 'my//index.php'],
+            ['https://example.com//index.php', 'https://example.com//index.php'],
+            ['https://example.com/index.php/', 'https://example.com/index.php'],
+        ];
+    }
+
+    /**
      * Tests get_redactable_param_names().
      *
      * @covers \tool_excimer\script_metadata::get_redactable_param_names


### PR DESCRIPTION
Assumes paths should not have a trailing slash (unless the path is empty). I can change this behaviour if required.

References: 
Issue #272
PR #285