### PR TITLE
Use relative path to graph php files in template javascript

### DIFF
--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -91,7 +91,7 @@ function init() {
 
     if (window.excimerData === undefined) {
         setLoading(true);
-        d3.json('/admin/tool/excimer/flamegraph.json.php?profileid={{id}}')
+        d3.json('flamegraph.json.php?profileid={{id}}')
             .then(function(data) {
                 setLoading(false);
                 window.excimerData = data;

--- a/templates/memoryusagegraph.mustache
+++ b/templates/memoryusagegraph.mustache
@@ -84,7 +84,7 @@ const memUsageInit = async () => {
     if (excimerData === undefined) {
         setLoading(true);
         try {
-            const data = await d3.json('/admin/tool/excimer/memoryusagegraph.json.php?profileid={{id}}')
+            const data = await d3.json('memoryusagegraph.json.php?profileid={{id}}')
             setLoading(false);
             excimerData = data;
             processGraph('memoryusagegraph', excimerData);


### PR DESCRIPTION
For (admittedly usually dev) Moodle sites located in a subdirectory of the apache root, the graphs can't be displayed because the template requests to the {...}graph.json.php files return 404 errors.

Prefixing the path with the actual wwwroot as defined in config.php fixes this.
Edit: Actually it doesn't (was testing in the wrong dev instance), but using a relative path does. These templates are only rendered in profile.php so this should be fine (I hope).