### PR TITLE
Update group logic for pluginfiles #335

### DIFF
--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -343,7 +343,7 @@ class script_metadata {
                 }
             }
             $params = $profile->get('parameters');
-            if ($params != '') {
+            if ($params != '' && !in_array($request, self::PLUGINFILE_SCRIPTS)) {
                 $val .= '?' . self::redact_parameters($params);
             }
             if (empty($val)) {
@@ -398,6 +398,8 @@ class script_metadata {
     public static function redact_pluginfile_pathinfo(string $pathinfo): string {
         $segments = explode('/', ltrim($pathinfo, '/'), 4);
         $segments[0] = 'x';
+        // Contextid for tokenpluginfile.php can be in $segments[1] depending on $CFG->slasharguments.
+        $segments[1] = ctype_digit($segments[1]) ? 'x' : $segments[1];
         $segments[3] = 'xxx';
         return '/' . implode('/', $segments);
     }

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -155,6 +155,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
             ['admin/index.php', '', 'a=1&b&c=3', 'admin/index.php?a=&b&c='],
             ['admin/index.php', '/1/2/3/', 'a=1&b&c=3', 'admin/index.php/x/x/x/?a=&b&c='],
             ['pluginfile.php', '/12/mod/book/3242/3/tool.png', '', 'pluginfile.php/x/mod/book/xxx'],
+            ['tokenpluginfile.php', '/token/12/user/private/0/image.png', '', 'tokenpluginfile.php/x/x/user/xxx'],
         ];
     }
 


### PR DESCRIPTION
Improves grouping for tokenpluginfile.php and removes params from pluginfile groups as there are a handful of cases where param names are timestamps or hashes.