### PR TITLE
Update duration display

### DIFF
--- a/classes/grouped_profile_table.php
+++ b/classes/grouped_profile_table.php
@@ -34,10 +34,10 @@ abstract class grouped_profile_table extends profile_table {
     /** Columns to be displayed.*/
     const COLUMNS = [
         'maxduration',
+        'minduration',
         'requestcount',
         'maxcreated',
         'mincreated',
-        'minduration',
     ];
 
     /** @var \moodle_url URL path to use for linking to profile groups. */
@@ -80,6 +80,25 @@ abstract class grouped_profile_table extends profile_table {
            $filterstring,
            $filterparams
         );
+    }
+
+    /**
+     * Defines the columns for this table.
+     *
+     * @throws \coding_exception
+     */
+    public function make_columns(): void {
+        $headers = [];
+        $columns = $this->get_columns();
+        foreach ($columns as $column) {
+            $headers[] = get_string('field_' . $column, 'tool_excimer');
+        }
+
+        $this->define_columns($columns);
+        $this->column_class('maxduration', 'text-right');
+        $this->column_class('minduration', 'text-right');
+        $this->column_class('requestcount', 'text-center');
+        $this->define_headers($headers);
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -88,7 +88,7 @@ class helper {
     }
 
     /**
-     * Returns a formatted time duration in a human readable format.
+     * Returns a formatted time duration in h:m:s format.
      *
      * @param float $duration
      * @param bool $markup If true, then use markup on the result.
@@ -96,6 +96,29 @@ class helper {
      * @throws \Exception
      */
     public static function duration_display(float $duration, bool $markup = true): string {
+        if (!$markup) {
+            return $duration;
+        }
+
+        $s = (int) $duration;
+        $h = $s / 3600;
+        $m = ($s % 3600) / 60;
+        $s = $s % 60;
+        $formatted = ($h >= 1) ? sprintf('%d:%02d:%02d', $h, $m, $s) : sprintf('%d:%02d', $m, $s);
+
+        // Make text monospace.
+        return \html_writer::tag('pre', $formatted, ['class' => 'm-0', 'style' => 'font-size: inherit;']);
+    }
+
+    /**
+     * Returns a formatted time duration in a human readable format.
+     *
+     * @param float $duration
+     * @param bool $markup If true, then use markup on the result.
+     * @return string
+     * @throws \Exception
+     */
+    public static function duration_display_text(float $duration, bool $markup = true): string {
         // Variable $markup allows a different format when viewed (true) vs downloaded (false).
         if ($markup) {
             if (intval($duration) > 10) {

--- a/profile.php
+++ b/profile.php
@@ -122,11 +122,11 @@ $data['created'] = userdate($data['created']);
 $data['finished'] = userdate($data['finished']);
 
 $duration = $data['duration'];
-$data['duration'] = helper::duration_display($duration, true);
+$data['duration'] = helper::duration_display_text($duration, true);
 if (isset($data['lockwait'])) {
     $lockwait = $data['lockwait'];
-    $data['lockwait'] = helper::duration_display($lockwait, true);
-    $data['lockheld'] = helper::duration_display($data['lockheld'], true);
+    $data['lockwait'] = helper::duration_display_text($lockwait, true);
+    $data['lockheld'] = helper::duration_display_text($data['lockheld'], true);
     $data['lockwaiturl'] = helper::lockwait_display_link($data['lockwaiturl'], $lockwait);
     $data['lockwaiturlhelp'] = helper::lockwait_display_help($OUTPUT, $data['lockwaiturl']);
 


### PR DESCRIPTION
Had some discussions with Brendan about changing how time is formatted.

There's been some back and forth over this in the past, i.e. https://github.com/catalyst/moodle-tool_excimer/issues/181, so I believe we're best keeping two separate functions for handling duration displays, which would make it easy to test and switch as needed.

We are leaning towards h:m:s in columns and human readable in profiles.