### PR TITLE
Add admin setting for partial save

### DIFF
--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -55,6 +55,10 @@ $string['enable_auto'] = 'Enable auto profiling';
 $string['enable_auto_desc'] = 'Any page will be automatically profiled if they exceed the miniumum duration.';
 $string['enable_fuzzy_count'] = 'Enable fuzzy counting';
 $string['enable_fuzzy_count_desc'] = 'This will cause the plugin to maintain an approximate count of page runs using the {$a}. Automatic profiling must also be enabled.';
+$string['enable_partial_save'] = 'Enable partial save';
+$string['enable_partial_save_desc'] = 'This will save partial profiles of slow web processes every processing interval. This
+    provides information about these processes while they are still running or if a container gets reaped, but the extra writes
+    can be problematic when experiencing large scale database issues.';
 $string['expiry_s'] = 'Log expiry (days)';
 $string['expiry_s_desc'] = 'Remove profiles after this long.';
 $string['num_slowest'] = 'Max to save';
@@ -66,8 +70,9 @@ $string['request_ms_desc'] = 'Record a profile only if it runs at least this lon
 $string['num_slowest_by_page'] = 'Max to save by page';
 $string['num_slowest_by_page_desc'] = 'Only the N slowest profiles will be kept for each script page.';
 $string['noexcimerprofiler'] = 'ExcimerProfiler class does not exist so profiling cannot continue. Please check the installation instructions {$a}.';
-$string['long_interval_s'] = 'Partial save interval (seconds)';
-$string['long_interval_s_desc'] = 'For long running taks, save a partial profile every N seconds.';
+$string['long_interval_s'] = 'Processing interval (seconds)';
+$string['long_interval_s_desc'] = 'Checks the current status of long running tasks every N seconds and processes as required.
+    This includes saving profiles of finished cron tasks and partial saves of ongoing web processes if enabled.';
 $string['task_min_duration'] = 'Task min duration (seconds)';
 $string['task_min_duration_desc'] = 'For scheduled and ad-hoc tasks, the minimum approx duration, in seconds.';
 $string['samplelimit'] = 'Sample limit';

--- a/settings.php
+++ b/settings.php
@@ -176,6 +176,15 @@ if ($hassiteconfig) {
             )
         );
 
+        $settings->add(
+            new admin_setting_configcheckbox(
+                'tool_excimer/enable_partial_save',
+                get_string('enable_partial_save', 'tool_excimer'),
+                get_string('enable_partial_save_desc', 'tool_excimer'),
+                0
+            )
+        );
+
         $item = new admin_setting_configtext(
             'tool_excimer/trigger_ms',
             get_string('request_ms', 'tool_excimer'),

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024050700;
-$plugin->release = 2024050700;
+$plugin->version = 2024052400;
+$plugin->release = 2024052400;
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 $plugin->supported = [35, 401];     // Supports Moodle 3.5 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
We've been noticing some issues with excimer appearing in its own profiles when a site is suffering wide scale database issues. This has been traced back to the partial save during web processing, and occur when db writes for the save are taking a significant amount of time. 

This goes against the design principle of do no harm, and really should have its own admin setting. The timing can be controlled by 'long_interval_s', but this is also used for saving profiles of finished cron tasks, so the new setting should be different.

This PR adds the setting (defaults to off) and updates the wording of the mentioned settings to reflect proper usage. 

There's room to improve the performance of partial saves, but that would be a separate issue and a toggle would still be desired. 