### PR TITLE
Images on profiler details page do not show if moodle isn't on root of web server

### DIFF
--- a/templates/flamegraph.mustache
+++ b/templates/flamegraph.mustache
@@ -91,7 +91,7 @@ function init() {
 
     if (window.excimerData === undefined) {
         setLoading(true);
-        d3.json('/admin/tool/excimer/flamegraph.json.php?profileid={{id}}')
+        d3.json('flamegraph.json.php?profileid={{id}}')
             .then(function(data) {
                 setLoading(false);
                 window.excimerData = data;

--- a/templates/memoryusagegraph.mustache
+++ b/templates/memoryusagegraph.mustache
@@ -84,7 +84,7 @@ const memUsageInit = async () => {
     if (excimerData === undefined) {
         setLoading(true);
         try {
-            const data = await d3.json('/admin/tool/excimer/memoryusagegraph.json.php?profileid={{id}}')
+            const data = await d3.json('memoryusagegraph.json.php?profileid={{id}}')
             setLoading(false);
             excimerData = data;
             processGraph('memoryusagegraph', excimerData);


### PR DESCRIPTION
For fixing it, I simply removed the path to memoryusagegraph.json.php and to flamegraph.json.php - so they are accessed relatively - and it works well.

Thnaks for your great work on this plugin !