### PR TITLE
Add unique index for page groups #348

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -61,7 +61,7 @@
     <TABLE NAME="tool_excimer_page_groups" COMMENT="Metadata about groups of profiles.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="256" NOTNULL="true" SEQUENCE="false" COMMENT="Group name"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="Group name"/>
         <FIELD NAME="month" TYPE="int" LENGTH="6" NOTNULL="true" SEQUENCE="false" COMMENT="Month in YYYYMM format."/>
         <FIELD NAME="fuzzycount" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="A approximate count of hits for this group using the approximate counting algorithm."/>
         <FIELD NAME="fuzzydurationcounts" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Breakdown of fuzzy counts for durations"/>
@@ -70,6 +70,9 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="pagegroup" UNIQUE="true" FIELDS="name, month"/>
+      </INDEXES>
     </TABLE>
   </TABLES>
 </XMLDB>

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024052400;
-$plugin->release = 2024052400;
+$plugin->version = 2024082301;
+$plugin->release = 2024082301;
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 $plugin->supported = [35, 401];     // Supports Moodle 3.5 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Closes #348 

We have a minor loss in data with concurrent updates that can cause duplicate rows, so this adds a unique index on name and month and catches unique key errors. 

This same problem does occur with updates when fuzzycount is low, but realistically this isn't a big concern as these are estimates, and the ones with the low fuzzycount will get updated quickly.

We don't want any sort of transactions or locking to ensure we do no harm - so best to ignore those cases.

For upgrade script logic:
- I've kept the page group with the higher fuzzycount. In most cases this is lopsided, but even when they are close the highest is still a reasonable estimate.
- I also had to change the precision of name to 255 to be able to add this as a unique index. We shouldn't have real page groups with names this long, but bad urls can exist so I've deleted those. 