### PR TITLE
[#353] Fix unit tests - strtotime returns incorrect month

### DIFF
--- a/tests/tool_excimer_purge_page_group_test.php
+++ b/tests/tool_excimer_purge_page_group_test.php
@@ -43,17 +43,17 @@ class tool_excimer_purge_page_group_test extends \advanced_testcase {
      */
     public function test_purge() {
         global $DB;
-
         $cutoff = 4;
+        $firstofthismonth = date('Y-m') . '-01';
         $months = [
             monthint::from_timestamp(time()),
-            monthint::from_timestamp(strtotime('1 month ago')),
-            monthint::from_timestamp(strtotime('2 months ago')),
-            monthint::from_timestamp(strtotime('3 months ago')),
-            monthint::from_timestamp(strtotime('4 months ago')),
-            monthint::from_timestamp(strtotime('5 months ago')),
-            monthint::from_timestamp(strtotime('6 months ago')),
-            monthint::from_timestamp(strtotime('7 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '1 month ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '2 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '3 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '4 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '5 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '6 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . '7 months ago')),
         ];
         foreach ($months as $month) {
             $DB->insert_record(page_group::TABLE, (object) ['month' => $month, 'fuzzydurationcounts' => '']);


### PR DESCRIPTION
There is a bug in strtotime() and month subtraction in the last 1-2 days in a month where the result month is February.
Adding a step to use the first day of the month as the source for the strtotime() function resolves this issue.