### PR TITLE
[#352] Resolve upgrade.php performance

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -496,13 +496,6 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         // First we need to drop a few edge cases that have a length of 256.
         $DB->delete_records_select('tool_excimer_page_groups', $DB->sql_length('name') . ' > 255');
 
-        // Changing precision of field name on table tool_excimer_page_groups to (255).
-        $table = new xmldb_table('tool_excimer_page_groups');
-        $field = new xmldb_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'id');
-
-        // Launch change of precision for field name.
-        $dbman->change_field_precision($table, $field);
-
         // Find all non-unique page groups and remove duplicates.
         $sql = " SELECT pgroups.id,
                         LOWER(pgroups.name) name,
@@ -543,6 +536,13 @@ function xmldb_tool_excimer_upgrade($oldversion) {
                 $DB->delete_records_select('tool_excimer_page_groups', "id IN ($removeids)");
             }
         }
+
+        // Changing precision of field name on table tool_excimer_page_groups to (255).
+        $table = new xmldb_table('tool_excimer_page_groups');
+        $field = new xmldb_field('name', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'id');
+
+        // Launch change of precision for field name.
+        $dbman->change_field_precision($table, $field);
 
         // Define index pagegroup (unique) to be added to tool_excimer_page_groups.
         $table = new xmldb_table('tool_excimer_page_groups');


### PR DESCRIPTION
- **perf: shift precision change until after deletes**
- **perf: update delete in php to SQL + optimised query**

Resolves #352 (would be good to have confirmation with larger site)

Script used to generate some local test data - which isn't as great as live data but better than no data!
- https://gist.github.com/keevan/529c4092c0cb1d90a675bc1d1a09d98b

Example local results (transaction errors are to ensure I can retest quickly - will omit in other results):

**Pre-patch**

```
❯ ctrl php admin/tool/excimer/dedupe-test.php
Number of duplicates found: 139058
Number of duplicates to remove: 115942
Number of duplicates remaining: 0
Execution time: 1.8240051269531 seconds!!! Database transaction error !!!
!! Transactions already disposed
Error code: dmltransactionexception !!
!! Stack trace: * line 103 of /lib/dml/moodle_transaction.php: dml_transaction_exception thrown
* line 121 of /admin/tool/excimer/dedupe-test.php: call to moodle_transaction-&gt;rollback()
 !!
```

**After precision reorder:**

```
❯ ctrl php admin/tool/excimer/dedupe-test.php
Number of duplicates found: 139058
Number of duplicates to remove: 115942
Number of duplicates remaining: 0
Execution time: 1.4179699420929 seconds
```

**After SQL + PHP change to pure SQL + optimisations**

```
❯ ctrl php admin/tool/excimer/dedupe-test.php
Execution time: 0.41718292236328 seconds
Number of records in tool_excimer_page_groups: 36146
```

The numbers might be skewed slightly based on what my machine was doing at the time, but is a rough estimate. I also generated more duplicates at some point to make it take longer, but it wasn't that significant.