### PR TITLE
Add lock user and time #320

### DIFF
--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -154,6 +154,10 @@ $string['field_pid'] = 'Process ID';
 $string['field_hostname'] = 'Host name';
 $string['field_useragent'] = 'User agent';
 $string['field_versionhash'] = 'Version Hash';
+$string['field_usermodified'] = 'User modified';
+$string['field_timecreated'] = 'Time created';
+$string['field_timemodified'] = 'Time modified';
+$string['field_lockreason'] = 'Lock reason';
 $string['field_courseid'] = 'Course';
 $string['field_lockheld'] = 'Session held';
 $string['field_lockwait'] = 'Session wait';
@@ -191,6 +195,7 @@ $string['reason_import'] = 'Import';
 // Lock reason form.
 $string['lock_profile'] = 'Lock Profile';
 $string['locked'] = 'Profile is locked';
+$string['lockedinfo'] = 'Locked by {$a->user} on {$a->date}';
 $string['lockreason'] = 'Lock Profile Reason';
 $string['lockreason_help'] = 'Submitting text will prevent this profile from being deleted.
     It will not be purged during cleanup tasks, nor can it be deleted manually (will also be excluded from group deletes).

--- a/lock_profile.php
+++ b/lock_profile.php
@@ -51,7 +51,8 @@ admin_externalpage_setup('tool_excimer_report_' . $reporttype);
 $form = new \tool_excimer\form\lock_reason_form($url);
 
 if ($data = $form->get_data()) {
-    $DB->update_record('tool_excimer_profiles', (object) ['id' => $profileid, 'lockreason' => trim($data->lockreason)]);
+    $lockreason = trim($data->lockreason);
+    $profile->update_lock($lockreason);
     redirect($data->returnurl);
 } else {
     $form->set_data(['lockreason' => $DB->get_field('tool_excimer_profiles', 'lockreason', ['id' => $profileid])]);

--- a/profile.php
+++ b/profile.php
@@ -198,6 +198,7 @@ if ($user) {
     $data['fullname'] = '-';
 }
 $data['lockreason'] = format_text($data['lockreason']);
+$data['lockmodified'] = helper::lock_display_modified($profile);
 $tabs = new tabs($url);
 
 // JavaScript locale string. Arguably "localecldr/langconfig" would be a better

--- a/templates/profile.mustache
+++ b/templates/profile.mustache
@@ -63,6 +63,9 @@
 {{#lockreason}}
     <div class="alert alert-info alert-block">
         <h4>{{#str}} locked, tool_excimer {{/str}}</h4>
+        {{#lockmodified}}
+            <div class="mb-2">{{{lockmodified}}}</div>
+        {{/lockmodified}}
         {{{lockreason}}}
     </div>
 {{/lockreason}}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024091200;
-$plugin->release = 2024091200;
+$plugin->version = 2024091600;
+$plugin->release = 2024091600;
 $plugin->requires = 2017051500;    // Moodle 3.3 for Totara support.
 $plugin->supported = [35, 401];     // Supports Moodle 3.5 or later.
 // TODO $plugin->incompatible = ;  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Closes #320 

Makes use of the existing usermodified and timemodified fields that are set when profiles are created or partially saved but never used. I can't see any reason to modify a profile aside from adding a lock.