### PR TITLE
Improve check for showing user who locked profile

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -322,9 +322,13 @@ class helper {
             return '';
         }
 
-        // We don't want to show user modified if it was set before the lock (i.e. during creation).
+        // We don't want to show user modified if it was set before the lock (i.e. during creation this is the profile user).
         // No exact comparison, but can check it's different from created or greater than finished plus a small buffer.
-        if ($modified === $profile->get('timecreated') || ($profile->get('finished') + 10) > $modified) {
+        // If a profile is unfinished we need to use a larger buffer to check against modified.
+        $created = $profile->get('timecreated');
+        $finished = $profile->get('finished');
+        $completed = !empty($finished) ? $finished + 10 : $created + DAYSECS;
+        if ($modified === $created || $completed > $modified) {
             return '';
         }
 


### PR DESCRIPTION
This is an edge where a profile is showing it was locked by the user of the profile because the check for usermodified during creation isn't working as intended for unfinished profiles https://github.com/catalyst/moodle-tool_excimer/pull/366/commits/41754541d1ce178adc105ff4a9d13e3ffc79161c#diff-5f8968976b6ffb6f4ed942f198c378ef4455b1c1dbf040cbc1100cfc2fbb736fR325-R329

These were locked when locking didn't change the user/time modified. This should be rare since we're no longer saving unfinished web pages, but it should be safe to add an extra buffer here.