### PR TITLE
Add after_config callback for older Moodle versions

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -41,7 +41,7 @@ function tool_excimer_before_session_start() {
  * After config
  *
  * This is a legacy callback that is used for compatibility with older Moodle versions.
- * Moodle 4.5+ will use tool_abconfig\hook_callbacks::after_config instead.
+ * Moodle 4.5+ will use tool_excimer\local\hooks\after_config::callback instead.
  *
  * @return void|null
  */

--- a/lib.php
+++ b/lib.php
@@ -38,6 +38,20 @@ function tool_excimer_before_session_start() {
 }
 
 /**
+ * After config
+ *
+ * This is a legacy callback that is used for compatibility with older Moodle versions.
+ * Moodle 4.5+ will use tool_abconfig\hook_callbacks::after_config instead.
+ *
+ * @return void|null
+ */
+function tool_excimer_after_config(): void {
+    // Start processor.
+    $manager = manager::get_instance();
+    $manager->start_processor();
+}
+
+/**
  * Hook to obtain a list of perfomence checks supplied by the plugin.
  *
  * @return \core\check\check[]

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024110100;
+$plugin->version = 2024110101;
 $plugin->release = 2024110100;
 $plugin->requires  = 2023100900; // Moodle 4.3.
 $plugin->supported = [403, 405];


### PR DESCRIPTION
The `core\hook\after_config hook` is for Moodle 4.5+, and 4.3 still needs the callback.

https://github.com/catalyst/moodle-tool_excimer/pull/371#issuecomment-2579160881