### PR TITLE
Fix for #374 MOODLE_35_STABLE branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<a href="https://github.com/catalyst/moodle-tool_excimer/actions/workflows/ci.yml?query=branch%3AMOODLE_35_STABLE">
-<img src="https://github.com/catalyst/moodle-tool_excimer/workflows/ci/badge.svg?branch=MOODLE_35_STABLE">
-</a>
+[![ci](https://github.com/catalyst/moodle-tool_excimer/actions/workflows/ci.yml/badge.svg?branch=MOODLE_35_STABLE)](https://github.com/catalyst/moodle-tool_excimer/actions/workflows/ci.yml?branch=MOODLE_35_STABLE)
 
 # moodle-tool_excimer
 


### PR DESCRIPTION
Fix for #374 - ci badge in README

Branch: MOODLE_35_STABLE

