### PR TITLE
Fix handling of querystrings #367

### DIFF
--- a/classes/local/hooks/after_config.php
+++ b/classes/local/hooks/after_config.php
@@ -56,9 +56,8 @@ class after_config {
             // Start processor.
             $manager = manager::get_instance();
             $manager->start_processor();
-        } catch (\Exception $exception) {
-            debugging('tool_excimer_after_config error',
-            DEBUG_DEVELOPER, $exception->getTrace());
+        } catch (\Throwable $e) {
+            debugging('tool_excimer_after_config error', DEBUG_DEVELOPER, $e->getTrace());
         }
 
     }

--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -139,7 +139,8 @@ class script_metadata {
             return implode(' ', array_slice($_SERVER['argv'], 1));
         }
 
-        if (isset($ME)) {
+        // There is a core bug where url::get_query string cannot handle nested array keys.
+        if (isset($ME) && !str_contains($ME, '][')) {
             $querystring = (new \moodle_url($ME))->get_query_string(false);
         } else if (isset($_SERVER['QUERY_STRING'])) {
             $querystring = $_SERVER['QUERY_STRING'];

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -86,8 +86,9 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @covers \tool_excimer\script_metadata::get_parameters
      * @param string $querystring
      * @param string $expected
+     * @param bool $fallback params that shouldn't be retrieved using $ME
      */
-    public function test_get_parameters(string $querystring, string $expected) {
+    public function test_get_parameters(string $querystring, string $expected, bool $fallback) {
         global $ME;
 
         script_metadata::init();
@@ -95,7 +96,11 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
         $globalme = $ME ?? null;
         $ME = 'abc.php?' . $querystring;
         $params = script_metadata::get_parameters(profile::SCRIPTTYPE_WEB);
-        $this->assertEquals($expected, $params);
+        if (!$fallback) {
+            $this->assertEquals($expected, $params);
+        } else {
+            $this->assertEquals('', $params);
+        }
         $ME = $globalme;
 
         $serverquerystring = $_SERVER['QUERY_STRING'] ?? null;
@@ -112,13 +117,15 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      */
     public function get_parameters_provider(): array {
         $args = [
-            ['a=1&b=2&c=3', 'a=1&b=2&c=3'],
+            ['a=1&b=2&c=3', 'a=1&b=2&c=3', false],
+            ['a[0]=1', http_build_query(['a' => ['0' => 1]]), false],
+            ['a[0][0]=1', http_build_query(['a' => ['0' => ['0' => 1]]]), true],
         ];
         foreach (script_metadata::DENY_LIST as $tobedenied) {
-            $args[] = ['a=1&b=2&' . $tobedenied . '=1', 'a=1&b=2'];
+            $args[] = ['a=1&b=2&' . $tobedenied . '=1', 'a=1&b=2', false];
         }
         foreach (script_metadata::REDACT_LIST as $toberedacted) {
-            $args[] = ['a=1&b=2&' . $toberedacted . '=1', 'a=1&b=2&' . $toberedacted . '='];
+            $args[] = ['a=1&b=2&' . $toberedacted . '=1', 'a=1&b=2&' . $toberedacted . '=', false];
         }
         return $args;
     }


### PR DESCRIPTION
There is a core bug where url::get_query_string() cannot handle nested array keys. `$_SERVER['QUERY_STRING']` is not always an exact match so I've left the original method as is and only use it as a fallback when the url contains a nested array key. 

The bug occurs when handling a page where the URL is a nested array key. It has a different impact depending on PHP and Moodle version:

|PHP | Moodle | Result |
|:------|:------|:-----|
|<8.1 | Any | Warning |
|8.1+ | 3.5-4.4 | Caught fatal exception, page loads without excimer (some other after_config may also fail) |
|8.1+ | 4.5+ | Fatal |

Moodle 4.5 removed the try/catch on after_config, which was added back here as catch Exception. This specific bug returns an Error, which was getting through this check. This has been updated to Throwable.