### PR TITLE
Make test provider functions static

### DIFF
--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -54,7 +54,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function strip_parameters_provider(): array {
+    public static function strip_parameters_provider(): array {
         return [
             [
                 '',
@@ -115,7 +115,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function get_parameters_provider(): array {
+    public static function get_parameters_provider(): array {
         $args = [
             ['a=1&b=2&c=3', 'a=1&b=2&c=3', false],
             ['a[0]=1', http_build_query(['a' => ['0' => 1]]), false],
@@ -155,7 +155,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      *
      * @return \string[][]
      */
-    public function scriptgroup_value_provider(): array {
+    public static function scriptgroup_value_provider(): array {
         return [
             ['admin/index.php', '', '', 'admin/index.php'],
             ['admin/index.php', '/a/54/c', '', 'admin/index.php/a/x/c'],
@@ -186,7 +186,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      *
      * @return \int[][]
      */
-    public function sampling_limit_provider(): array {
+    public static function sampling_limit_provider(): array {
         return [
             [0, 1024],
             [1, 1],
@@ -213,7 +213,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * Provider for test_get_normalised_relative_script_path().
      * @return \string[][]
      */
-    public function relative_script_path_provider(): array {
+    public static function relative_script_path_provider(): array {
         return [
             ['', '/'],
             ['/', '/'],
@@ -259,7 +259,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      *
      * @return array[]
      */
-    public function get_redactable_param_names_provider(): array {
+    public static function get_redactable_param_names_provider(): array {
         return [
             [
                 "extra\nfeeble\n",


### PR DESCRIPTION
For runtests in Moodle 5.0
Resolves "Data Provider method … is not static" error.