### PR TITLE
Update cron task names #389

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -166,7 +166,7 @@ class cron_processor implements processor {
         $length = count($trace);
         for ($i = 0; $i < $length; ++$i) {
             $fnname = $trace[$i]['function'] ?? null;
-            if ($fnname == 'cron_run_inner_scheduled_task' || $fnname == 'cron_run_inner_adhoc_task') {
+            if ($fnname == 'run_inner_scheduled_task' || $fnname == 'run_inner_adhoc_task') {
                 if ($i + 1 < $length) {
                     if ('execute' == ($trace[$i + 1]['function'] ?? null)) {
                         return $trace[$i + 1]['class'];

--- a/tests/tool_excimer_cron_processor_test.php
+++ b/tests/tool_excimer_cron_processor_test.php
@@ -49,11 +49,11 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         $taskname = $processor->findtaskname($entry);
         $this->assertNull($taskname);
 
-        $entry = $this->get_log_entry_stub(['bud', 'cron_run_inner_scheduled_task', 'ced::execute']);
+        $entry = $this->get_log_entry_stub(['bud', 'run_inner_scheduled_task', 'ced::execute']);
         $taskname = $processor->findtaskname($entry);
         $this->assertEquals('ced', $taskname);
 
-        $entry = $this->get_log_entry_stub(['bud', 'cron_run_inner_scheduled_task', 'max']);
+        $entry = $this->get_log_entry_stub(['bud', 'run_inner_scheduled_task', 'max']);
         $taskname = $processor->findtaskname($entry);
         $this->assertNull($taskname);
     }
@@ -90,8 +90,8 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
         // Adding 3 more samples.
         $profiler = $this->get_profiler_stub([
             ['a', 'b'],
-            ['cron_run_inner_scheduled_task', 'max::execute', 'read::john'],
-            ['cron_run_inner_scheduled_task', 'max::execute'],
+            ['run_inner_scheduled_task', 'max::execute', 'read::john'],
+            ['run_inner_scheduled_task', 'max::execute'],
         ], $period, ($period * 1));
 
         $manager = $this->get_manager_stub($processor, $profiler, $timer, $started);
@@ -105,9 +105,9 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
 
         // Adding four more samples. Should record two sample sets into the database.
         $profiler = $this->get_profiler_stub([
-            ['cron_run_inner_scheduled_task', 'max::execute'],
+            ['run_inner_scheduled_task', 'max::execute'],
             ['a', 'b'],
-            ['cron_run_inner_adhoc_task', 'simle::execute'],
+            ['run_inner_adhoc_task', 'simle::execute'],
             ['a', 'b'],
         ], $period, ($period * 4));
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024110101;
-$plugin->release = 2024110100;
+$plugin->version = 2025041700;
+$plugin->release = 2025041700;
 $plugin->requires  = 2023100900; // Moodle 4.3.
 $plugin->supported = [403, 405];
 $plugin->component = 'tool_excimer';


### PR DESCRIPTION
Resolves #389 

Related to https://tracker.moodle.org/browse/MDL-77186 updating the task names for Moodle 4.2+. 