### PR TITLE
purge_page_groups: make 'months ago' cutoff the middle of the month

### DIFF
--- a/classes/task/purge_page_groups.php
+++ b/classes/task/purge_page_groups.php
@@ -48,7 +48,7 @@ class purge_page_groups extends \core\task\scheduled_task {
         $months = get_config('tool_excimer', 'expiry_fuzzy_counts');
         // Only purge if a value is set.
         if (!empty($months)) {
-            $month = monthint::from_timestamp(strtotime(($months + 1) . ' months ago'));
+            $month = monthint::from_timestamp(strtotime('second Monday of' . ($months + 1) . ' months ago'));
             $DB->delete_records_select(page_group::TABLE, 'month <= ' . $month);
         }
     }

--- a/tests/tool_excimer_purge_page_group_test.php
+++ b/tests/tool_excimer_purge_page_group_test.php
@@ -47,13 +47,13 @@ class tool_excimer_purge_page_group_test extends \advanced_testcase {
         $firstofthismonth = date('Y-m') . '-01';
         $months = [
             monthint::from_timestamp(time()),
-            monthint::from_timestamp(strtotime($firstofthismonth . '1 month ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '2 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '3 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '4 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '5 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '6 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '7 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 1 month ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 2 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 3 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 4 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 5 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 6 months ago')),
+            monthint::from_timestamp(strtotime($firstofthismonth . 'second Monday of 7 months ago')),
         ];
         foreach ($months as $month) {
             $DB->insert_record(page_group::TABLE, (object) ['month' => $month, 'fuzzydurationcounts' => '']);
@@ -80,7 +80,7 @@ class tool_excimer_purge_page_group_test extends \advanced_testcase {
         $this->assertEquals($cutoff + 1, count($records));
 
         // Check that no month stored is earlier than the cutoff month.
-        $cutoffmonth = monthint::from_timestamp(strtotime(($cutoff + 1) . ' months ago'));
+        $cutoffmonth = monthint::from_timestamp(strtotime('second Monday of' . ($cutoff + 1) . ' months ago'));
         foreach ($records as $record) {
             $this->assertGreaterThan($cutoffmonth, (int) $record->month);
         }


### PR DESCRIPTION
Resolves month-rollover issue where previous months have fewer days.

Currently tool_excimer_purge_page_group_test fails on
* the 29th of March-September, unless it's a leap year;
* the 30th of March-September
* the 31st of every month that has a 31st

This is due to documented behaviour of the [php core function strtotime](https://www.php.net/manual/en/function.strtotime.php#refsect1-function.strtotime-notes).