### PR TITLE
Improve purge page group test and scheduled task

### DIFF
--- a/classes/profile_helper.php
+++ b/classes/profile_helper.php
@@ -79,7 +79,7 @@ class profile_helper {
         $cachekey = $group;
         $cachefield = 'min_duration_for_reason_' . $reason . '_s';
         $cache = \cache::make('tool_excimer', 'request_metadata');
-        $result = $cache->get($cachekey) ?: array();
+        $result = $cache->get($cachekey) ?: [];
 
         if (!$usecache || empty($result) || !isset($result[$cachefield])) {
             // NOTE: Opting to query this way instead of using MIN due to
@@ -130,7 +130,7 @@ class profile_helper {
 
         $cachefield = 'profile_type_' . $reason . '_min_duration_s';
         $cache = \cache::make('tool_excimer', 'request_metadata');
-        $result = $cache->get(self::ALL_GROUP_CACHE_KEY) ?: array();
+        $result = $cache->get(self::ALL_GROUP_CACHE_KEY) ?: [];
 
         if (!$usecache || empty($result) || !isset($result[$cachefield])) {
             // Get and set cache.

--- a/classes/recent_profile_table.php
+++ b/classes/recent_profile_table.php
@@ -36,7 +36,7 @@ class recent_profile_table extends profile_table {
         'duration',
         'lockwait',
         'userid',
-        'courseid'
+        'courseid',
     ];
 
     /**

--- a/classes/task/purge_page_groups.php
+++ b/classes/task/purge_page_groups.php
@@ -39,17 +39,52 @@ class purge_page_groups extends \core\task\scheduled_task {
     }
 
     /**
-     * Do the job.
+     * Execute the scheduled task.
+     *
+     * @param int|null $now Optional timestamp for testing
      */
-    public function execute() {
+    public function execute(?int $now = null) {
+        $this->purge($now ?? time());
+    }
+
+    /**
+     * Purge page group records older than the retention period.
+     *
+     * @param int $now Current timestamp (injectable for tests)
+     */
+    public function purge(int $now): void {
         global $DB;
 
-        // Because we want to keep n full months of data, we add one to include the current month.
-        $months = get_config('tool_excimer', 'expiry_fuzzy_counts');
-        // Only purge if a value is set.
-        if (!empty($months)) {
-            $month = monthint::from_timestamp(strtotime(($months + 1) . ' months ago'));
-            $DB->delete_records_select(page_group::TABLE, 'month <= ' . $month);
+        $keepmonths = (int)get_config('tool_excimer', 'expiry_fuzzy_counts');
+
+        if (!empty($keepmonths) && $keepmonths > 0) {
+            $cutoff = $this->calculate_cutoff_month($now, $keepmonths);
+
+            // Delete all page group records less than or equal our cutoff month.
+            $DB->delete_records_select(page_group::TABLE, 'month <= ' . $cutoff);
         }
     }
+
+    /**
+     * Calculate the cutoff month number based on $now and months to keep.
+     *
+     * @param int $now Current timestamp
+     * @param int $keepmonths Number of months to retain
+     * @return int Cutoff month number (for comparison in DB)
+     */
+    public function calculate_cutoff_month(int $now, int $keepmonths): int {
+        // Because we want to keep n full months of data (n = $keepmonths).
+        // We add one month ($keepmonths += 1) to include the current month.
+        $keepmonths += 1;
+
+        $date = new \DateTime();
+        $date->setTimestamp($now);
+        $date->modify('first day of this month');
+        $date->modify("-{$keepmonths} months");
+
+        // Return a custom from_timestamp year/month number (e.g., 202508).
+        // We can call this custom timestamp the "cutoff month".
+        return monthint::from_timestamp($date->getTimestamp());
+    }
+
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -410,7 +410,7 @@ function xmldb_tool_excimer_upgrade($oldversion) {
         $table->add_field('fuzzydurationsum', XMLDB_TYPE_INTEGER, '11', null, XMLDB_NOTNULL, null, 0);
 
         // Adding keys to table tool_excimer_profile_groups.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
 
         // Conditionally launch create table for tool_excimer_profile_groups.
         if (!$dbman->table_exists($table)) {

--- a/lang/en/tool_excimer.php
+++ b/lang/en/tool_excimer.php
@@ -24,9 +24,9 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['adminname'] = 'Excimer profiler';
 $string['pluginname'] = 'Excimer profiler';
 $string['reportname'] = 'Profiler reports';
-$string['adminname'] = 'Excimer profiler';
 
 // Admin Tree.
 $string['report_slowest'] = 'Slowest profiles';

--- a/tests/tool_excimer_cron_processor_test.php
+++ b/tests/tool_excimer_cron_processor_test.php
@@ -28,7 +28,7 @@ require_once(__DIR__ . "/excimer_testcase.php"); // This is needed. File will no
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_cron_processor_test extends excimer_testcase {
+final class tool_excimer_cron_processor_test extends excimer_testcase {
 
     /**
      * Set up before each test
@@ -43,7 +43,7 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
      *
      * @covers \tool_excimer\cron_processor::findtaskname
      */
-    public function test_findtaskname() {
+    public function test_findtaskname(): void {
         $processor = new cron_processor();
         $entry = $this->get_log_entry_stub(['c::a', 'b', 'c']);
         $taskname = $processor->findtaskname($entry);
@@ -63,7 +63,7 @@ class tool_excimer_cron_processor_test extends excimer_testcase {
      *
      * @covers \tool_excimer\cron_processor::on_interval
      */
-    public function test_on_interval() {
+    public function test_on_interval(): void {
         global $DB;
         $this->preventResetByRollback();
 

--- a/tests/tool_excimer_flamed3_node_test.php
+++ b/tests/tool_excimer_flamed3_node_test.php
@@ -30,7 +30,7 @@ require_once(__DIR__ . "/excimer_testcase.php"); // This is needed. File will no
  * @copyright 2021, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_flamed3_node_test extends excimer_testcase {
+final class tool_excimer_flamed3_node_test extends excimer_testcase {
 
     /**
      * Set up before each test

--- a/tests/tool_excimer_helper_test.php
+++ b/tests/tool_excimer_helper_test.php
@@ -25,11 +25,11 @@ namespace tool_excimer;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers \tool_excimer\helper
  */
-class tool_excimer_helper_test extends \advanced_testcase {
+final class tool_excimer_helper_test extends \advanced_testcase {
     /**
      * Tests course_display_name function
      */
-    public function test_course_display_name() {
+    public function test_course_display_name(): void {
         $this->resetAfterTest(true);
 
         // Test with real course.
@@ -44,7 +44,7 @@ class tool_excimer_helper_test extends \advanced_testcase {
     /**
      * Tests course_display_link function
      */
-    public function test_course_display_link() {
+    public function test_course_display_link(): void {
         $this->resetAfterTest(true);
 
         // Test with real course.

--- a/tests/tool_excimer_manager_test.php
+++ b/tests/tool_excimer_manager_test.php
@@ -24,7 +24,7 @@ namespace tool_excimer;
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_manager_test extends \advanced_testcase {
+final class tool_excimer_manager_test extends \advanced_testcase {
 
     /**
      * Set up before each test
@@ -78,7 +78,7 @@ class tool_excimer_manager_test extends \advanced_testcase {
      *
      * @covers \tool_excimer\manager::approximate_increment
      */
-    public function test_approximate_increment() {
+    public function test_approximate_increment(): void {
         // Run tests for the first portion of expected counts.
         for ($expectedcount = 0; $expectedcount <= 10; $expectedcount++) {
             $current = 0;

--- a/tests/tool_excimer_mockery_test.php
+++ b/tests/tool_excimer_mockery_test.php
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-
 namespace tool_excimer;
 
 defined('MOODLE_INTERNAL') || die();
@@ -29,7 +28,7 @@ require_once(__DIR__ . "/excimer_testcase.php"); // This is needed. File will no
  * @copyright  2022, Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_mockery_test extends excimer_testcase {
+final class tool_excimer_mockery_test extends excimer_testcase {
 
     /**
      * Tests excimer_mockery::get_log_entry_stub()

--- a/tests/tool_excimer_profile_helper_test.php
+++ b/tests/tool_excimer_profile_helper_test.php
@@ -25,7 +25,7 @@ namespace tool_excimer;
  * @copyright  2022 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_profile_helper_test extends \advanced_testcase {
+final class tool_excimer_profile_helper_test extends \advanced_testcase {
 
     /**
      * Set up before each test
@@ -401,7 +401,7 @@ class tool_excimer_profile_helper_test extends \advanced_testcase {
      *
      * @covers \tool_excimer\profile
      */
-    public function test_minimal_db_reads_writes_for_warm_cache() {
+    public function test_minimal_db_reads_writes_for_warm_cache(): void {
         global $DB;
         $this->preventResetByRollback();
 

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -25,7 +25,7 @@ namespace tool_excimer;
  * @copyright  2022 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_profile_test extends \advanced_testcase {
+final class tool_excimer_profile_test extends \advanced_testcase {
 
     /**
      * Set up before each test
@@ -169,7 +169,7 @@ class tool_excimer_profile_test extends \advanced_testcase {
      *
      * @covers \tool_excimer\profile::save_record
      */
-    public function test_partial_save() {
+    public function test_partial_save(): void {
         $this->preventResetByRollback();
 
         $log = $this->quick_log(1); // TODO change to use stubs.
@@ -255,7 +255,7 @@ class tool_excimer_profile_test extends \advanced_testcase {
      *
      * @covers \tool_excimer\profile::save_record
      */
-    public function test_save_course() {
+    public function test_save_course(): void {
         global $COURSE, $DB;
         $this->preventResetByRollback();
 

--- a/tests/tool_excimer_purge_page_group_test.php
+++ b/tests/tool_excimer_purge_page_group_test.php
@@ -19,14 +19,14 @@ namespace tool_excimer;
 use tool_excimer\task\purge_page_groups;
 
 /**
- * <insertdescription>
+ * Testing the purge page group scheduled task execution method
  *
  * @package   tool_excimer
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_purge_page_group_test extends \advanced_testcase {
+final class tool_excimer_purge_page_group_test extends \advanced_testcase {
 
     /**
      * Set up before each test
@@ -41,48 +41,88 @@ class tool_excimer_purge_page_group_test extends \advanced_testcase {
      *
      * @covers \tool_excimer\task\purge_page_groups::execute
      */
-    public function test_purge() {
+    public function test_purge(): void {
         global $DB;
-        $cutoff = 4;
-        $firstofthismonth = date('Y-m') . '-01';
+
+        // Set test static page group records for previous months.
         $months = [
-            monthint::from_timestamp(time()),
-            monthint::from_timestamp(strtotime($firstofthismonth . '1 month ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '2 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '3 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '4 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '5 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '6 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '7 months ago')),
+            202507, // July 2025.
+            202506, // June 2025.
+            202505, // May 2025.
+            202504, // April 2025.
+            202503, // March 2025.
+            202502, // February 2025.
+            202501, // January 2025.
+            202412, // December 2024.
         ];
-        foreach ($months as $month) {
-            $DB->insert_record(page_group::TABLE, (object) ['month' => $month, 'fuzzydurationcounts' => '']);
-        }
 
-        $count = $DB->count_records(page_group::TABLE);
-        $this->assertEquals(count($months), $count); // Sanity check.
+        // Fixed "now" for an injectable static date test.
+        // Testing 31st of July 2025, a date affected by datetime rollover issues.
+        // If 31st July passes then all affected dates and normal dates will.
+        $now = new \DateTime('2025-07-31');
 
-        // Test no value set, should do no purging.
-        set_config('expiry_fuzzy_counts', '', 'tool_excimer');
-        $task = new purge_page_groups();
-        $task->execute();
+        $this->populate_test_data($months);
+
+        // Assertion 1: Sanity check that all records were inserted.
         $count = $DB->count_records(page_group::TABLE);
         $this->assertEquals(count($months), $count);
 
-        // Test a value of $cutoff, all but $cutoff + 1 rows should be purged.
-        set_config('expiry_fuzzy_counts', $cutoff, 'tool_excimer');
+        // Assertion 2: No value set, should do no purging.
+        set_config('expiry_fuzzy_counts', '', 'tool_excimer');
         $task = new purge_page_groups();
-        $task->execute();
+        $task->execute($now->getTimestamp());
+        $count = $DB->count_records(page_group::TABLE);
+        $this->assertEquals(count($months), $count);
 
+        // Assertion 3: Keep more months than already exist, should do no purging.
+        $keepmonths = 20;
+        set_config('expiry_fuzzy_counts', $keepmonths, 'tool_excimer');
+        $task = new purge_page_groups();
+        $task->execute($now->getTimestamp());
+        $this->assertEquals(count($months), $count);
+
+        // Assertion 4: All except $keepmonths should be purged.
+        $keepmonths = 5;
+        set_config('expiry_fuzzy_counts', $keepmonths, 'tool_excimer');
+        $task = new purge_page_groups();
+        $task->execute($now->getTimestamp());
         $records = $DB->get_records(page_group::TABLE);
+        // Addition equation here.
+        // Ensures n full months + current month.
+        $this->assertEquals($keepmonths + 1, count($records));
 
-        // Check that the number of records remaining is the correct number.
-        $this->assertEquals($cutoff + 1, count($records));
+        // Assertion 5: Cutoff is expected
+        $expectedcutoff = 202501;
+        $cutoffmonth = $task->calculate_cutoff_month($now->getTimestamp(), $keepmonths);
+        $this->assertEquals($expectedcutoff, $cutoffmonth);
 
-        // Check that no month stored is earlier than the cutoff month.
-        $cutoffmonth = monthint::from_timestamp(strtotime(($cutoff + 1) . ' months ago'));
+        // Assertion 6: Ensure no month older than cutoff remains.
+        $cutoffmonth = $task->calculate_cutoff_month($now->getTimestamp(), $keepmonths);
         foreach ($records as $record) {
             $this->assertGreaterThan($cutoffmonth, (int) $record->month);
+        }
+    }
+
+    /**
+     * Populate test data
+     *
+     * @param array $months Required test month data
+     * @param bool|null $reset Optional to reset the data in the table
+     */
+    protected function populate_test_data(array $months, ?bool $reset = null): void {
+        global $DB;
+
+        if ($reset === true) {
+            // Delete all test records.
+            $DB->delete_records(page_group::TABLE);
+        }
+
+        // Insert the test months.
+        foreach ($months as $month) {
+            $DB->insert_record(page_group::TABLE, (object) [
+                'month' => $month,
+                'fuzzydurationcounts' => '',
+            ]);
         }
     }
 }

--- a/tests/tool_excimer_sample_set_test.php
+++ b/tests/tool_excimer_sample_set_test.php
@@ -29,14 +29,14 @@ require_once(__DIR__ . "/excimer_testcase.php");
  * @copyright  2022 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_sample_set_test extends excimer_testcase {
+final class tool_excimer_sample_set_test extends excimer_testcase {
 
     /**
      * Tests adding samples to the object.
      *
      * @covers \tool_excimer\sample_set::add_many_samples
      */
-    public function test_add_sample() {
+    public function test_add_sample(): void {
         $samples = [
             $this->get_log_entry_stub(['a']),
             $this->get_log_entry_stub(['b']),
@@ -56,7 +56,7 @@ class tool_excimer_sample_set_test extends excimer_testcase {
      * @covers \tool_excimer\sample_set::add_many_samples
      * @covers \tool_excimer\sample_set::apply_doubling
      */
-    public function test_filtering() {
+    public function test_filtering(): void {
         $samples = [
             $this->get_log_entry_stub(['a']),
             $this->get_log_entry_stub(['b']),
@@ -98,7 +98,7 @@ class tool_excimer_sample_set_test extends excimer_testcase {
      * @covers \tool_excimer\sample_set::add_many_samples
      * @covers \tool_excimer\sample_set::apply_doubling
      */
-    public function test_stripping() {
+    public function test_stripping(): void {
         $samples = [
             $this->get_log_entry_stub(['a']),
             $this->get_log_entry_stub(['b']),
@@ -131,7 +131,7 @@ class tool_excimer_sample_set_test extends excimer_testcase {
      *
      * @covers \tool_excimer\sample_set::add_many_samples
      */
-    public function test_automatic_doubling_when_adding_samples() {
+    public function test_automatic_doubling_when_adding_samples(): void {
         $samples1 = [
             $this->get_log_entry_stub(['a']),
             $this->get_log_entry_stub(['b']),
@@ -180,7 +180,7 @@ class tool_excimer_sample_set_test extends excimer_testcase {
      *
      * @covers \tool_excimer\sample_set::add_many_samples
      */
-    public function test_event_count() {
+    public function test_event_count(): void {
         script_metadata::init();
         $eventcounts = [1, 1, 4, 1, 2, 1];
         $samples1 = [

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -24,7 +24,7 @@ namespace tool_excimer;
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_script_metadata_test extends \advanced_testcase {
+final class tool_excimer_script_metadata_test extends \advanced_testcase {
 
     /**
      * Set up before each test
@@ -43,7 +43,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param array $params
      * @param array $expected
      */
-    public function test_strip_parameters(string $config, array $params, array $expected) {
+    public function test_strip_parameters(string $config, array $params, array $expected): void {
         set_config('redact_params', $config, 'tool_excimer');
         script_metadata::init();
         $this->assertEquals($expected, script_metadata::strip_parameters($params));
@@ -88,7 +88,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param string $expected
      * @param bool $fallback params that shouldn't be retrieved using $ME
      */
-    public function test_get_parameters(string $querystring, string $expected, bool $fallback) {
+    public function test_get_parameters(string $querystring, string $expected, bool $fallback): void {
         global $ME;
 
         script_metadata::init();
@@ -140,7 +140,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param string $parameters
      * @param string $expected
      */
-    public function test_get_groupby_value(string $request, string $pathinfo, string $parameters, string $expected) {
+    public function test_get_groupby_value(string $request, string $pathinfo, string $parameters, string $expected): void {
         script_metadata::init();
         $profile = new profile();
         $profile->set('request', $request);
@@ -174,7 +174,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param int $limit
      * @param int $expected
      */
-    public function test_get_sample_limit(int $limit, int $expected) {
+    public function test_get_sample_limit(int $limit, int $expected): void {
         $this->preventResetByRollback();
         set_config('samplelimit', $limit, 'tool_excimer');
         script_metadata::init();
@@ -203,7 +203,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param string $path
      * @param string $expected
      */
-    public function test_get_normalised_relative_script_path(string $path, string $expected) {
+    public function test_get_normalised_relative_script_path(string $path, string $expected): void {
         script_metadata::init();
         $this->assertEquals($expected, script_metadata::get_normalised_relative_script_path($path, null));
         $this->assertEquals($expected, script_metadata::get_normalised_relative_script_path(null, $path));
@@ -248,7 +248,7 @@ class tool_excimer_script_metadata_test extends \advanced_testcase {
      * @param string $config
      * @param array $expected
      */
-    public function test_get_redactable_param_names(string $config, array $expected) {
+    public function test_get_redactable_param_names(string $config, array $expected): void {
         set_config('redact_params', $config, 'tool_excimer');
         script_metadata::init();
         $this->assertEquals($expected, script_metadata::get_redactable_param_names());


### PR DESCRIPTION
This work stemmed from a review of a pull request that tried to resolve this issue: https://github.com/catalyst/moodle-tool_excimer/issues/397

The review of that pull request is here: https://github.com/catalyst/moodle-tool_excimer/pull/394

This work also resolves the issue in https://github.com/catalyst/moodle-tool_excimer/issues/397. The difference is that it;

1. Tries to make the test and scheduled task more clear as to what they each do.
2. Introduces static month data and time injection to the test rather than using dynamic dates (safer and predictable).
3. Reduces time calculations in the affected test where possible. 
4. Add a new test to check if the user wants to retain more months than in the database, then keep all data. Seemed relevant to add, with time injection now possible in this test its easy to test edge cases like this.
5. The purge page groups scheduled task was also modified to suit the modifications made to the related test.