### PR TITLE
Totara 19 purge page group test and task improvements

### DIFF
--- a/classes/task/purge_page_groups.php
+++ b/classes/task/purge_page_groups.php
@@ -39,17 +39,52 @@ class purge_page_groups extends \core\task\scheduled_task {
     }
 
     /**
-     * Do the job.
+     * Execute the scheduled task.
+     *
+     * @param int|null $now Optional timestamp for testing
      */
-    public function execute() {
+    public function execute(?int $now = null) {
+        $this->purge($now ?? time());
+    }
+
+    /**
+     * Purge page group records older than the retention period.
+     *
+     * @param int $now Current timestamp (injectable for tests)
+     */
+    public function purge(int $now): void {
         global $DB;
 
-        // Because we want to keep n full months of data, we add one to include the current month.
-        $months = get_config('tool_excimer', 'expiry_fuzzy_counts');
-        // Only purge if a value is set.
-        if (!empty($months)) {
-            $month = monthint::from_timestamp(strtotime(($months + 1) . ' months ago'));
-            $DB->delete_records_select(page_group::TABLE, 'month <= ' . $month);
+        $keepmonths = (int)get_config('tool_excimer', 'expiry_fuzzy_counts');
+
+        if (!empty($keepmonths) && $keepmonths > 0) {
+            $cutoff = $this->calculate_cutoff_month($now, $keepmonths);
+
+            // Delete all page group records less than or equal our cutoff month.
+            $DB->delete_records_select(page_group::TABLE, 'month <= ' . $cutoff);
         }
     }
+
+    /**
+     * Calculate the cutoff month number based on $now and months to keep.
+     *
+     * @param int $now Current timestamp
+     * @param int $keepmonths Number of months to retain
+     * @return int Cutoff month number (for comparison in DB)
+     */
+    public function calculate_cutoff_month(int $now, int $keepmonths): int {
+        // Because we want to keep n full months of data (n = $keepmonths).
+        // We add one month ($keepmonths += 1) to include the current month.
+        $keepmonths += 1;
+
+        $date = new \DateTime();
+        $date->setTimestamp($now);
+        $date->modify('first day of this month');
+        $date->modify("-{$keepmonths} months");
+
+        // Return a custom from_timestamp year/month number (e.g., 202508).
+        // We can call this custom timestamp the "cutoff month".
+        return monthint::from_timestamp($date->getTimestamp());
+    }
+
 }

--- a/tests/tool_excimer_purge_page_group_test.php
+++ b/tests/tool_excimer_purge_page_group_test.php
@@ -27,7 +27,7 @@ use tool_excimer\page_group;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-final class tool_excimer_purge_page_group_test extends \advanced_testcase {
+final class tool_excimer_purge_page_group_test extends \core_phpunit\testcase {
     /**
      * Set up before each test
      */

--- a/tests/tool_excimer_purge_page_group_test.php
+++ b/tests/tool_excimer_purge_page_group_test.php
@@ -19,15 +19,15 @@ use tool_excimer\monthint;
 use tool_excimer\page_group;
 
 /**
- * <insertdescription>
+ * Testing the purge page group scheduled task execution method
  *
  * @package   tool_excimer
  * @author    Jason den Dulk <jasondendulk@catalyst-au.net>
  * @copyright 2022, Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_excimer_purge_page_group_test extends \core_phpunit\testcase {
 
+final class tool_excimer_purge_page_group_test extends \advanced_testcase {
     /**
      * Set up before each test
      */
@@ -41,48 +41,88 @@ class tool_excimer_purge_page_group_test extends \core_phpunit\testcase {
      *
      * @covers \tool_excimer\task\purge_page_groups::execute
      */
-    public function test_purge() {
+    public function test_purge(): void {
         global $DB;
-        $cutoff = 4;
-        $firstofthismonth = date('Y-m') . '-01';
+
+        // Set test static page group records for previous months.
         $months = [
-            monthint::from_timestamp(time()),
-            monthint::from_timestamp(strtotime($firstofthismonth . '1 month ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '2 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '3 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '4 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '5 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '6 months ago')),
-            monthint::from_timestamp(strtotime($firstofthismonth . '7 months ago')),
+            202507, // July 2025.
+            202506, // June 2025.
+            202505, // May 2025.
+            202504, // April 2025.
+            202503, // March 2025.
+            202502, // February 2025.
+            202501, // January 2025.
+            202412, // December 2024.
         ];
-        foreach ($months as $month) {
-            $DB->insert_record(page_group::TABLE, (object) ['month' => $month, 'fuzzydurationcounts' => '']);
-        }
 
-        $count = $DB->count_records(page_group::TABLE);
-        $this->assertEquals(count($months), $count); // Sanity check.
+        // Fixed "now" for an injectable static date test.
+        // Testing 31st of July 2025, a date affected by datetime rollover issues.
+        // If 31st July passes then all affected dates and normal dates will.
+        $now = new \DateTime('2025-07-31');
 
-        // Test no value set, should do no purging.
-        set_config('expiry_fuzzy_counts', '', 'tool_excimer');
-        $task = new purge_page_groups();
-        $task->execute();
+        $this->populate_test_data($months);
+
+        // Assertion 1: Sanity check that all records were inserted.
         $count = $DB->count_records(page_group::TABLE);
         $this->assertEquals(count($months), $count);
 
-        // Test a value of $cutoff, all but $cutoff + 1 rows should be purged.
-        set_config('expiry_fuzzy_counts', $cutoff, 'tool_excimer');
+        // Assertion 2: No value set, should do no purging.
+        set_config('expiry_fuzzy_counts', '', 'tool_excimer');
         $task = new purge_page_groups();
-        $task->execute();
+        $task->execute($now->getTimestamp());
+        $count = $DB->count_records(page_group::TABLE);
+        $this->assertEquals(count($months), $count);
 
+        // Assertion 3: Keep more months than already exist, should do no purging.
+        $keepmonths = 20;
+        set_config('expiry_fuzzy_counts', $keepmonths, 'tool_excimer');
+        $task = new purge_page_groups();
+        $task->execute($now->getTimestamp());
+        $this->assertEquals(count($months), $count);
+
+        // Assertion 4: All except $keepmonths should be purged.
+        $keepmonths = 5;
+        set_config('expiry_fuzzy_counts', $keepmonths, 'tool_excimer');
+        $task = new purge_page_groups();
+        $task->execute($now->getTimestamp());
         $records = $DB->get_records(page_group::TABLE);
+        // Addition equation here.
+        // Ensures n full months + current month.
+        $this->assertEquals($keepmonths + 1, count($records));
 
-        // Check that the number of records remaining is the correct number.
-        $this->assertEquals($cutoff + 1, count($records));
+        // Assertion 5: Cutoff is expected
+        $expectedcutoff = 202501;
+        $cutoffmonth = $task->calculate_cutoff_month($now->getTimestamp(), $keepmonths);
+        $this->assertEquals($expectedcutoff, $cutoffmonth);
 
-        // Check that no month stored is earlier than the cutoff month.
-        $cutoffmonth = monthint::from_timestamp(strtotime(($cutoff + 1) . ' months ago'));
+        // Assertion 6: Ensure no month older than cutoff remains.
+        $cutoffmonth = $task->calculate_cutoff_month($now->getTimestamp(), $keepmonths);
         foreach ($records as $record) {
             $this->assertGreaterThan($cutoffmonth, (int) $record->month);
+        }
+    }
+
+    /**
+     * Populate test data
+     *
+     * @param array $months Required test month data
+     * @param bool|null $reset Optional to reset the data in the table
+     */
+    protected function populate_test_data(array $months, ?bool $reset = null): void {
+        global $DB;
+
+        if ($reset === true) {
+            // Delete all test records.
+            $DB->delete_records(page_group::TABLE);
+        }
+
+        // Insert the test months.
+        foreach ($months as $month) {
+            $DB->insert_record(page_group::TABLE, (object) [
+                'month' => $month,
+                'fuzzydurationcounts' => '',
+            ]);
         }
     }
 }


### PR DESCRIPTION
This work stemmed from a review of a pull request that tried to resolve this issue: https://github.com/catalyst/moodle-tool_excimer/issues/397

The review of that pull request is here: https://github.com/catalyst/moodle-tool_excimer/pull/394

This work also resolves the issue in https://github.com/catalyst/moodle-tool_excimer/issues/397. The difference is that it;

1. Tries to make the test and scheduled task more clear as to what they each do.
2. Introduces static month data and time injection to the test rather than using dynamic dates (safer and predictable).
3. Reduces time calculations in the affected test where possible.
4. Add a new test to check if the user wants to retain more months than in the database, then keep all data. Seemed relevant to add, with time injection now possible in this test its easy to test edge cases like this.
5. The purge page groups scheduled task was also modified to suit the modifications made to the related test.