### PR TITLE
fix "Deprecation notice requested" debugging notice

### DIFF
--- a/classes/profile.php
+++ b/classes/profile.php
@@ -294,10 +294,11 @@ class profile extends persistent {
         // Get DB ops (reads/writes).
         $this->raw_set('dbreads', $DB->perf_get_reads());
         $this->raw_set('dbwrites', $DB->perf_get_writes());
-        $this->raw_set(
-            'dbreplicareads',
-            (method_exists($DB, 'want_read_slave') && $DB->want_read_slave()) ? $DB->perf_get_reads_slave() : 0
-        );
+        if (method_exists($DB, 'want_read_replica')) {
+            $this->raw_set('dbreplicareads', $DB->want_read_replica() ? $DB->perf_get_reads_replica() : 0);
+        } else {
+            $this->raw_set('dbreplicareads', $DB->want_read_slave() ? $DB->perf_get_reads_slave() : 0);
+        }
 
         $this->raw_set('responsecode', http_response_code());
 


### PR DESCRIPTION
Noting that $DB->want_read_slave() came into being in 3.9, so testing for its existence before calling it is no longer worthwhile.

fixes #407