### PR TITLE
Set up altconnection with base config #406

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -63,7 +63,7 @@ class manager {
      * @return false|\moodle_database|null
      */
     public static function get_altconnection() {
-        global $DB;
+        global $CFG, $DB;
 
         // Do not use an alternate connection during unit tests.
         if (PHPUNIT_TEST) {
@@ -71,11 +71,10 @@ class manager {
         }
 
         if (is_null(self::$altconnection)) {
-            $cfg = $DB->export_dbconfig();
-            self::$altconnection = \moodle_database::get_driver_instance($cfg->dbtype, $cfg->dblibrary);
+            self::$altconnection = \moodle_database::get_driver_instance($CFG->dbtype, $CFG->dblibrary);
             try {
                 self::$altconnection->connect(
-                    $cfg->dbhost, $cfg->dbuser, $cfg->dbpass, $cfg->dbname, $cfg->prefix, $cfg->dboptions);
+                    $CFG->dbhost, $CFG->dbuser, $CFG->dbpass, $CFG->dbname, $CFG->prefix, $CFG->dboptions);
             } catch (\moodle_exception $e) {
                 // Rather than engage with complex error handling, we choose to simply not record, and move on.
                 debugging('tool_excimer: failed to open second DB connection when saving profile: ' . $e->getMessage());


### PR DESCRIPTION
Closes #406 

In one of the examples $DB->export_dbconfig() was returning the read only connection for dbhost, causing inserts to fail. There may be more requirements to replicate this. 

From my understanding changing to using $CFG values should still be relatively safe.