### PR TITLE
Increase sampling time when reach sample limit #403

### DIFF
--- a/classes/cron_processor.php
+++ b/classes/cron_processor.php
@@ -57,7 +57,7 @@ class cron_processor implements processor {
         });
 
         // Preload config values to avoid DB access during processing. See manager::get_altconnection() for more information.
-        $this->samplems = (int) get_config('tool_excimer', 'sample_ms');
+        $this->samplems = script_metadata::get_sampling_period();
 
         \core_shutdown_manager::register_function(
             function () use ($manager) {
@@ -79,6 +79,12 @@ class cron_processor implements processor {
      */
     public function get_min_duration(): float {
         return (float) get_config('tool_excimer', 'task_min_duration');
+    }
+
+    public function on_reach_limit(manager $manager) {
+        $this->samplems *= 2;
+        $manager->get_profiler()->setPeriod($this->samplems);
+        $manager->get_profiler()->start();
     }
 
     /**
@@ -136,8 +142,10 @@ class cron_processor implements processor {
 
             // If the sampleset exists, add the current sample to it.
             if ($this->tasksampleset) {
-                $this->tasksampleset->add_sample($sample);
-
+                $doubling  = $this->tasksampleset->add_sample($sample);
+                if ($doubling){
+                    $this->on_reach_limit($manager);
+                }
                 // Add memory usage:
                 // Note that due to the looping this is probably inaccurate.
                 $this->memoryusagesampleset->add_sample([
@@ -198,7 +206,7 @@ class cron_processor implements processor {
             $profile->set('memoryusagedatad3', $this->memoryusagesampleset->samples);
             $profile->set('flamedatad3', flamed3_node::from_excimer_log_entries($this->tasksampleset->samples));
             $profile->set('numsamples', $this->tasksampleset->count());
-            $profile->set('samplerate', $this->tasksampleset->filter_rate() * $this->samplems);
+            $profile->set('samplerate', $this->samplems * 1000);
             $profile->save_record();
         }
         return $profile;

--- a/classes/sample_set.php
+++ b/classes/sample_set.php
@@ -27,6 +27,7 @@ namespace tool_excimer;
 class sample_set {
     /** @var string name of the sample set. */
     public $name;
+
     /** @var float Starting time of the sample set. */
     public $starttime;
 
@@ -75,9 +76,10 @@ class sample_set {
      * @param array|\ExcimerLogEntry $sample
      */
     public function add_sample($sample) {
-        $trace = false;
+        $doubling = false;
         if (count($this->samples) === $this->samplelimit) {
             $this->apply_doubling();
+            $doubling = true;
         }
         $this->counter += 1;
         if ($this->counter === $this->filterrate) {
@@ -93,9 +95,10 @@ class sample_set {
             if ($trace) {
                 $this->maxstackdepth = max($this->maxstackdepth, count($trace));
             }
-            return;
+        } else {
+            $this->totaladded++;
         }
-        $this->totaladded++;
+        return $doubling;
     }
 
     /**


### PR DESCRIPTION
Refresh profiler period when we reach sample limit to slow down sampling speed.

Here is the test result:
```
Adhoc task id: 165
... started 02:36:24. Current memory use 20.2 MB.
Timer callback with log size 1000 at 1764729394
Timer callback with log size 1000 at 1764729404
Reach limit increase sampling time to 20 ms at 1764729404
Timer callback with log size 500 at 1764729414
Reach limit increase sampling time to 40 ms at 1764729414
Timer callback with log size 250 at 1764729424
Timer callback with log size 250 at 1764729434
Timer callback with log size 250 at 1764729444
Timer callback with log size 250 at 1764729454
Timer callback with log size 250 at 1764729464
Timer callback with log size 250 at 1764729474
Timer callback with log size 250 at 1764729484
Reach limit increase sampling time to 80 ms at 1764729484
Finish
```