### PR TITLE
Fix sql dml_read_exception with space after COUNT function

### DIFF
--- a/tests/quick_save_trait.php
+++ b/tests/quick_save_trait.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer;
+
+/**
+ * Trait providing a convenience method to save profile records in tests.
+ *
+ * @package    tool_excimer
+ * @copyright  2026 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+trait quick_save_trait {
+    /**
+     * A convenience function to save a profile record.
+     *
+     * @param string $request
+     * @param flamed3_node $node
+     * @param int $reason
+     * @param float $duration
+     * @param int $created
+     * @param string $lockreason
+     * @return int The ID of the record.
+     */
+    public function quick_save(
+        string $request,
+        flamed3_node $node,
+        int $reason,
+        float $duration,
+        int $created = 12345,
+        string $lockreason = ''
+    ): int {
+        $profile = new profile();
+        $profile->add_env($request);
+        $profile->set('reason', $reason);
+        $profile->set('flamedatad3', $node);
+        $profile->set('created', $created);
+        $profile->set('duration', $duration);
+        $profile->set('finished', $created + 2);
+        $profile->set('lockreason', $lockreason);
+        return $profile->save_record();
+    }
+}

--- a/tests/tool_excimer_grouped_profile_table_test.php
+++ b/tests/tool_excimer_grouped_profile_table_test.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/quick_save_trait.php");
+
+/**
+ * Tests for grouped_profile_table SQL generation.
+ *
+ * @package    tool_excimer
+ * @copyright  2026 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \tool_excimer\grouped_profile_table
+ */
+final class tool_excimer_grouped_profile_table_test extends excimer_testcase {
+    use quick_save_trait;
+
+    /**
+     * Set up before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        profile_helper::init();
+        script_metadata::init();
+    }
+
+    /**
+     * Test that the grouped script profile table query executes without SQL errors.
+     *
+     * Regression test: COUNT (CASE ...) with a space between COUNT and the
+     * opening parenthesis caused "FUNCTION dbname.COUNT does not exist" on
+     * MySQL servers without the IGNORE_SPACE sql_mode.
+     */
+    public function test_grouped_script_profile_table_query_executes(): void {
+        $node = new flamed3_node('root', 0);
+
+        $this->quick_save('/course/view.php?id=1', $node, profile::REASON_SLOW, 2.5);
+        $this->quick_save('/course/view.php?id=2', $node, profile::REASON_SLOW, 1.0);
+        $this->quick_save('/mod/assign/view.php?id=3', $node, profile::REASON_SLOW, 3.0, 12345, 'test lock');
+
+        $table = new grouped_script_profile_table('test_grouped_script');
+        $table->set_scripttypes([profile::SCRIPTTYPE_WEB, profile::SCRIPTTYPE_AJAX]);
+
+        $url = new \moodle_url('/admin/tool/excimer/slowest_web.php');
+        $table->set_url_path($url);
+        $table->sortable(true, 'maxduration', SORT_DESC);
+        $table->define_baseurl($url);
+        $table->make_columns();
+
+        $this->expectOutputRegex('/.+/s');
+        $table->out(40, true);
+    }
+
+    /**
+     * Test that the lockedcount aggregation in grouped tables works correctly.
+     *
+     * Verifies that the COUNT(CASE WHEN lockreason != '' ...) expression
+     * correctly counts only profiles with a non-empty lock reason.
+     */
+    public function test_grouped_table_lockedcount(): void {
+        global $DB;
+
+        $node = new flamed3_node('root', 0);
+
+        $this->quick_save('/test/page.php', $node, profile::REASON_SLOW, 1.0, 12345, '');
+        $this->quick_save('/test/page.php', $node, profile::REASON_SLOW, 2.0, 12345, 'locked for review');
+        $this->quick_save('/test/page.php', $node, profile::REASON_SLOW, 3.0, 12345, 'another reason');
+
+        $records = $DB->get_records_sql(
+            "SELECT scriptgroup,
+                    COUNT(request) as requestcount,
+                    COUNT(CASE WHEN lockreason != '' THEN 1 END) as lockedcount
+               FROM {tool_excimer_profiles}
+              WHERE scriptgroup IS NOT NULL
+           GROUP BY scriptgroup",
+            []
+        );
+
+        $this->assertCount(1, $records);
+        $record = reset($records);
+        $this->assertEquals(3, $record->requestcount);
+        $this->assertEquals(2, $record->lockedcount);
+    }
+}

--- a/tests/tool_excimer_profile_helper_test.php
+++ b/tests/tool_excimer_profile_helper_test.php
@@ -16,6 +16,10 @@
 
 namespace tool_excimer;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/quick_save_trait.php");
+
 /**
  * Defines names of plugin types and some strings used at the plugin managment
  *
@@ -26,6 +30,8 @@ namespace tool_excimer;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class tool_excimer_profile_helper_test extends \advanced_testcase {
+    use quick_save_trait;
+
     /**
      * Set up before each test
      */
@@ -70,37 +76,6 @@ final class tool_excimer_profile_helper_test extends \advanced_testcase {
         $prof->stop();
         return $prof->flush();
     }
-
-    /**
-     * A convenience function to save a profile.
-     *
-     * @param string $request
-     * @param flamed3_node $node
-     * @param int $reason
-     * @param float $duration
-     * @param int $created
-     * @param string $lockreason
-     * @return int The ID of the record.
-     */
-    public function quick_save(
-        string $request,
-        flamed3_node $node,
-        int $reason,
-        float $duration,
-        int $created = 12345,
-        string $lockreason = ''
-    ): int {
-        $profile = new profile();
-        $profile->add_env($request);
-        $profile->set('reason', $reason);
-        $profile->set('flamedatad3', $node);
-        $profile->set('created', $created);
-        $profile->set('duration', $duration);
-        $profile->set('finished', $created + 2);
-        $profile->set('lockreason', $lockreason);
-        return $profile->save_record();
-    }
-
 
     /**
      * Parse log entry to sample

--- a/tests/tool_excimer_profile_test.php
+++ b/tests/tool_excimer_profile_test.php
@@ -16,6 +16,10 @@
 
 namespace tool_excimer;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/quick_save_trait.php");
+
 /**
  * Defines names of plugin types and some strings used at the plugin managment
  *
@@ -26,6 +30,8 @@ namespace tool_excimer;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class tool_excimer_profile_test extends \advanced_testcase {
+    use quick_save_trait;
+
     /**
      * Set up before each test
      */
@@ -95,27 +101,6 @@ final class tool_excimer_profile_test extends \advanced_testcase {
         }
         $prof->stop();
         return $prof->flush();
-    }
-
-    /**
-     * A convenience function to save a profile.
-     *
-     * @param string $request
-     * @param flamed3_node $node
-     * @param int $reason
-     * @param float $duration
-     * @param int $created
-     * @return int The ID of the record.
-     */
-    public function quick_save(string $request, flamed3_node $node, int $reason, float $duration, int $created = 12345): int {
-        $profile = new profile();
-        $profile->add_env($request);
-        $profile->set('reason', $reason);
-        $profile->set('flamedatad3', $node);
-        $profile->set('created', $created);
-        $profile->set('duration', $duration);
-        $profile->set('finished', $created + 2);
-        return $profile->save_record();
     }
 
     /**


### PR DESCRIPTION
The grouped profile table pages (slowest_web.php, slowest_cli.php, etc.) throw a dml_read_exception on MySQL
without IGNORE_SPACE in sql_mode, which is the default (STRICT_ALL_TABLES is set by core):

```
FUNCTION dbname.COUNT does not exist.
Check the 'Function Name Parsing and Resolution' section in the Reference Manual
```

### Test


The test now runs the table->out() function, and without this fix has an error in default mysql 9.6 and 8.X: 

```
vendor/bin/phpunit --filter tool_excimer_grouped_profile_table_test
Moodle 4.5.8+ (Build: 20260116), 3c33567cad20e60a8382ea3e9e3b1f59a4bde5f5
Php: 8.3.30, mysqli: 9.6.0, OS: Darwin 25.4.0 arm64
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

E.                                                                  2 / 2 (100%)

Time: 00:00.826, Memory: 410.00 MB

There was 1 error:

1) tool_excimer\tool_excimer_grouped_profile_table_test::test_grouped_script_profile_table_query_executes
dml_read_exception: Error reading from database (FUNCTION test.COUNT does not exist. Check the 'Function Name Parsing and Resolution' section in the Reference Manual
```



One line fix to remove that space, thanks!
