### PR TITLE
Fix undefined variable $title when rendering profile table

### DIFF
--- a/classes/profile_table.php
+++ b/classes/profile_table.php
@@ -294,7 +294,7 @@ class profile_table extends \table_sql {
                     IGNORE_MISSING
                 );
                 if ($locker) {
-                    $icon = $OUTPUT->pix_icon('i/lock', $title);
+                    $icon = $OUTPUT->pix_icon('i/lock', $lockerlabel);
                     $lockerlabel = $icon . get_string('locked_by', 'tool_excimer', fullname($locker));
                 }
             }

--- a/tests/tool_excimer_profile_table_test.php
+++ b/tests/tool_excimer_profile_table_test.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_excimer;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . "/quick_save_trait.php");
+
+/**
+ * Tests for profile_table column rendering.
+ *
+ * @package    tool_excimer
+ * @copyright  2026 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \tool_excimer\profile_table
+ */
+final class tool_excimer_profile_table_test extends excimer_testcase {
+    use quick_save_trait;
+
+    /**
+     * Set up before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        profile_helper::init();
+        script_metadata::init();
+    }
+
+    /**
+     * Regression test: col_request used undefined $title in pix_icon alt text.
+     */
+    public function test_col_request_locked_profile_lock_icon_alt(): void {
+        global $DB, $PAGE;
+
+        $this->setAdminUser();
+        $node = new flamed3_node('root', 0);
+        $id = $this->quick_save('/test/page.php', $node, profile::REASON_SLOW, 2.0);
+
+        $profile = profile::get_record(['id' => $id]);
+        $profile->update_lock('locked for review');
+        $record = $DB->get_record('tool_excimer_profiles', ['id' => $id]);
+
+        $table = new recent_profile_table('test_profile_table');
+        $url = new \moodle_url('/admin/tool/excimer/slowest_web.php');
+        $table->define_baseurl($url);
+        $table->make_columns();
+        $PAGE->set_url($url);
+
+        $html = $table->col_request($record);
+
+        $this->assertStringContainsString(get_string('locked', 'tool_excimer'), $html);
+        $this->assertStringContainsString(get_string('locked_by', 'tool_excimer', 'Admin User'), $html);
+    }
+}


### PR DESCRIPTION
 col_request() referenced an undefined $title variable when rendering the lock icon for locked profiles.


The test also shows the issue, without the fix: 

```
vendor/bin/phpunit --testsuite tool_excimer_testsuite --filter tool_excimer_profile_table_test
Moodle 4.5.8+ (Build: 20260116), 3c33567cad20e60a8382ea3e9e3b1f59a4bde5f5
Php: 8.3.30, mysqli: 9.6.0, OS: Darwin 25.4.0 arm64
PHPUnit 9.6.29 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 00:00.314, Memory: 78.50 MB

There was 1 error:

1) tool_excimer\tool_excimer_profile_table_test::test_col_request_locked_profile_lock_icon_alt
Undefined variable $title

/Users/kristian/projects/ringertech/nsw-dep-edu/vetss-app-evidencecentral/admin/tool/excimer/classes/profile_table.php:297
/Users/kristian/projects/ringertech/nsw-dep-edu/vetss-app-evidencecentral/admin/tool/excimer/tests/tool_excimer_profile_table_test.php:90
/Users/kristian/projects/ringertech/nsw-dep-edu/vetss-app-evidencecentral/lib/phpunit/classes/advanced_testcase.php:76

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

One line fix, @brendanheywood , is this something you can review? Thank you!
