### PR TITLE
Prevent tool_excimer from accessing closed session data

### DIFF
--- a/classes/script_metadata.php
+++ b/classes/script_metadata.php
@@ -471,6 +471,10 @@ class script_metadata {
      */
     public static function get_lock_info(): array {
         $lockinfo = [];
+        // Session may have been closed before shutdown processing.
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            return $lockinfo;
+        }
         $sessionlock = \core\session\manager::get_session_lock_info();
         if (empty($sessionlock)) {
             return $lockinfo;

--- a/tests/tool_excimer_script_metadata_test.php
+++ b/tests/tool_excimer_script_metadata_test.php
@@ -271,4 +271,19 @@ final class tool_excimer_script_metadata_test extends \advanced_testcase {
             ],
         ];
     }
+
+    /**
+     * Tests get_lock_info() returns no information after the session is closed.
+     *
+     * Excimer processing can happen during shutdown after a script has called
+     * \core\session\manager::write_close(). Session lock information must not be
+     * accessed after the session has been closed.
+     *
+     * @covers \tool_excimer\script_metadata::get_lock_info
+     */
+    public function test_get_lock_info_with_closed_session(): void {
+        \core\session\manager::write_close();
+
+        $this->assertSame([], script_metadata::get_lock_info());
+    }
 }


### PR DESCRIPTION
Hi everyone,

After installing the plugin in our project, we noticed that running CI caused a number of Behat failures.

We investigated and found that `tool_excimer` can access session-lock information after Moodle has already closed the session with `\core\session\manager::write_close()`.

This can happen because Excimer processes profiling data during PHP shutdown.

Currently, `script_metadata::get_lock_info()` calls `get_session_lock_info()` without checking whether the session is still active.

We propose adding this check:

```php
if (session_status() !== PHP_SESSION_ACTIVE) {
    return [];
}
```

This is a small and safe fix in `tool_excimer` without changing Moodle core. Closing the session early is valid Moodle behaviour, so the plugin should simply avoid accessing session data after it has been closed.

We also added a regression test to verify that `get_lock_info()` returns an empty array after the session is closed. The test fails with the current code and passes with this fix.
